### PR TITLE
Removed hopefully all references to Javascript pointing to openSUSE pages

### DIFF
--- a/2008/04/29/index.html
+++ b/2008/04/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/04/29/orbit-iex-20-23052008/index.html
+++ b/2008/04/29/orbit-iex-20-23052008/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/04/index.html
+++ b/2008/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/07/easy-obs-web-client-development/index.html
+++ b/2008/05/07/easy-obs-web-client-development/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/07/index.html
+++ b/2008/05/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/07/open-soap-box/index.html
+++ b/2008/05/07/open-soap-box/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/07/talking-bootloader-heard-in-beta2/index.html
+++ b/2008/05/07/talking-bootloader-heard-in-beta2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/13/hamradio-packages-for-opensuse-110/index.html
+++ b/2008/05/13/hamradio-packages-for-opensuse-110/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/13/index.html
+++ b/2008/05/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/14/discussing-garden-ornaments/index.html
+++ b/2008/05/14/discussing-garden-ornaments/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/14/index.html
+++ b/2008/05/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/14/wiki-on-a-stick/index.html
+++ b/2008/05/14/wiki-on-a-stick/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/15/index.html
+++ b/2008/05/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/15/indonesian-opensuse-community-monthly-meeting-on-detikcom/index.html
+++ b/2008/05/15/indonesian-opensuse-community-monthly-meeting-on-detikcom/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/15/speed-and-memory-usage-of-zypp-in-110-rocks/index.html
+++ b/2008/05/15/speed-and-memory-usage-of-zypp-in-110-rocks/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/15/zimbra-collaboration-suite-50x-auto-install-script/index.html
+++ b/2008/05/15/zimbra-collaboration-suite-50x-auto-install-script/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/16/22/index.html
+++ b/2008/05/16/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/16/index.html
+++ b/2008/05/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/16/various-way-for-promoting-opensuse/index.html
+++ b/2008/05/16/various-way-for-promoting-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/19/index.html
+++ b/2008/05/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/19/opensuse-110-beta-3-testing/index.html
+++ b/2008/05/19/opensuse-110-beta-3-testing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/19/playing-with-opensuse-on-liveusb-stick/index.html
+++ b/2008/05/19/playing-with-opensuse-on-liveusb-stick/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/20/help-with-bug-hunting/index.html
+++ b/2008/05/20/help-with-bug-hunting/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/20/index.html
+++ b/2008/05/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/20/orbit-first-impressions/index.html
+++ b/2008/05/20/orbit-first-impressions/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/21/collaboration/index.html
+++ b/2008/05/21/collaboration/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/21/garden-party/index.html
+++ b/2008/05/21/garden-party/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/21/index.html
+++ b/2008/05/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/21/opensuse-liveusb-with-kiwi/index.html
+++ b/2008/05/21/opensuse-liveusb-with-kiwi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/23/index.html
+++ b/2008/05/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/23/today-agenda-opensuse-id-monthly-meeting/index.html
+++ b/2008/05/23/today-agenda-opensuse-id-monthly-meeting/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/26/index.html
+++ b/2008/05/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/26/learning-ruby/index.html
+++ b/2008/05/26/learning-ruby/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/27/index.html
+++ b/2008/05/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/27/indonesian-opensuse-monthly-meeting-may-2008/index.html
+++ b/2008/05/27/indonesian-opensuse-monthly-meeting-may-2008/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/27/preparation-for-opensuse-booth-on-igos-summit-2/index.html
+++ b/2008/05/27/preparation-for-opensuse-booth-on-igos-summit-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/28/im-going-to-linuxtag/index.html
+++ b/2008/05/28/im-going-to-linuxtag/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/28/index.html
+++ b/2008/05/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/29/bringing-opensuse-users-into-the-community/index.html
+++ b/2008/05/29/bringing-opensuse-users-into-the-community/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/29/index.html
+++ b/2008/05/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/29/it-builds/index.html
+++ b/2008/05/29/it-builds/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/31/index.html
+++ b/2008/05/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/31/making-opensuse-110-liveusb-the-easiest-and-fastest-way/index.html
+++ b/2008/05/31/making-opensuse-110-liveusb-the-easiest-and-fastest-way/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/index.html
+++ b/2008/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/page/2/index.html
+++ b/2008/05/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/05/page/3/index.html
+++ b/2008/05/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/01/home-again/index.html
+++ b/2008/06/01/home-again/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/01/index.html
+++ b/2008/06/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/03/110-installation-walk-throughs-mostly-done/index.html
+++ b/2008/06/03/110-installation-walk-throughs-mostly-done/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/03/index.html
+++ b/2008/06/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/04/index.html
+++ b/2008/06/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/04/opensuse-110-and-vista-users-poor-souls-hows-dual-booting/index.html
+++ b/2008/06/04/opensuse-110-and-vista-users-poor-souls-hows-dual-booting/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/05/index.html
+++ b/2008/06/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/05/opensuse-110-now-available-for-pre-order/index.html
+++ b/2008/06/05/opensuse-110-now-available-for-pre-order/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/06/find-your-monitor/index.html
+++ b/2008/06/06/find-your-monitor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/06/index.html
+++ b/2008/06/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/06/instsource-creation/index.html
+++ b/2008/06/06/instsource-creation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/07/index.html
+++ b/2008/06/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/07/toms-musings/index.html
+++ b/2008/06/07/toms-musings/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/09/boost-signals-as-hooks-to-extend-libzypp/index.html
+++ b/2008/06/09/boost-signals-as-hooks-to-extend-libzypp/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/09/index.html
+++ b/2008/06/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Maybe you know this problem: You have a couple of XML files and you need a specific information. Probably everybody would think of grep or similar tools first. But maybe your query is a bit more complicated than just a simple piece of text. What do do?" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/09/opensuse-training-at-state-ministry-for-youth-affairs-and-sports/index.html
+++ b/2008/06/09/opensuse-training-at-state-ministry-for-youth-affairs-and-sports/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/09/query-your-xml-with-xpathgreppy/index.html
+++ b/2008/06/09/query-your-xml-with-xpathgreppy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Maybe you know this problem: You have a couple of XML files and you need a specific information. Probably everybody would think of grep or similar tools first. But maybe your query is a bit more complicated than just a simple piece of text. What do do?" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/10/index.html
+++ b/2008/06/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/10/welcome-to-the-official-opensuse-forums/index.html
+++ b/2008/06/10/welcome-to-the-official-opensuse-forums/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/10/xfce-project-status-report-062008/index.html
+++ b/2008/06/10/xfce-project-status-report-062008/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/11/build-service-10-release-candidate-is-out/index.html
+++ b/2008/06/11/build-service-10-release-candidate-is-out/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/11/calling-all-gardens/index.html
+++ b/2008/06/11/calling-all-gardens/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/11/index.html
+++ b/2008/06/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/14/converting-babylon-dictionaries-to-stardict-format-in-opensuse/index.html
+++ b/2008/06/14/converting-babylon-dictionaries-to-stardict-format-in-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/14/index.html
+++ b/2008/06/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/16/carrying-community-radios/index.html
+++ b/2008/06/16/carrying-community-radios/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/16/firmwareupdatekit/index.html
+++ b/2008/06/16/firmwareupdatekit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/16/index.html
+++ b/2008/06/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/16/little-hermes/index.html
+++ b/2008/06/16/little-hermes/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/17/index.html
+++ b/2008/06/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/17/nntp-access-to-the-opensuse-forums/index.html
+++ b/2008/06/17/nntp-access-to-the-opensuse-forums/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/19/garden-party-2/index.html
+++ b/2008/06/19/garden-party-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/19/hamradio-packages-ready/index.html
+++ b/2008/06/19/hamradio-packages-ready/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/19/how-to-search-more-efficiently-in-bugzilla-with-pybugz/index.html
+++ b/2008/06/19/how-to-search-more-efficiently-in-bugzilla-with-pybugz/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="If you just want to search for bugs in Bugzilla, it's (a bit) painful: start the browser, type in the URL, insert your login and password and try to find out where to go. There is an easier way to do: pybugz for commandline lovers!" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/19/index.html
+++ b/2008/06/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/20/hermes-grows-up/index.html
+++ b/2008/06/20/hermes-grows-up/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/20/how-to-makeopensuse-110-gm-version-live-usb/index.html
+++ b/2008/06/20/how-to-makeopensuse-110-gm-version-live-usb/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/20/index.html
+++ b/2008/06/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/20/install-opensuse-without-burning-cds/index.html
+++ b/2008/06/20/install-opensuse-without-burning-cds/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/20/opensuse-110-at-first-glance-its-ok/index.html
+++ b/2008/06/20/opensuse-110-at-first-glance-its-ok/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/25/get-your-opensuse-posters-posters-for-everyone/index.html
+++ b/2008/06/25/get-your-opensuse-posters-posters-for-everyone/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/25/index.html
+++ b/2008/06/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/27/index.html
+++ b/2008/06/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/27/showing-package-dependencies/index.html
+++ b/2008/06/27/showing-package-dependencies/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/index.html
+++ b/2008/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/page/2/index.html
+++ b/2008/06/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/06/page/3/index.html
+++ b/2008/06/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/04/index.html
+++ b/2008/07/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/04/moving-forward-with-opensuse-111/index.html
+++ b/2008/07/04/moving-forward-with-opensuse-111/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/10/buildservice-and-l3/index.html
+++ b/2008/07/10/buildservice-and-l3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/10/index.html
+++ b/2008/07/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/10/new-osc-package-released/index.html
+++ b/2008/07/10/new-osc-package-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/12/extract-and-compress-right-click-menu-on-kde4/index.html
+++ b/2008/07/12/extract-and-compress-right-click-menu-on-kde4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/12/index.html
+++ b/2008/07/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/14/atheros-ar-5007-eg-on-opensuse-110/index.html
+++ b/2008/07/14/atheros-ar-5007-eg-on-opensuse-110/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/14/index.html
+++ b/2008/07/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/14/lrluk08-freeing-the-lizard/index.html
+++ b/2008/07/14/lrluk08-freeing-the-lizard/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/15/index.html
+++ b/2008/07/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/15/yast-module-the-c-way/index.html
+++ b/2008/07/15/yast-module-the-c-way/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/16/index.html
+++ b/2008/07/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/16/meeting-by-the-pond/index.html
+++ b/2008/07/16/meeting-by-the-pond/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/16/opensuse-gets-the-jeos/index.html
+++ b/2008/07/16/opensuse-gets-the-jeos/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/16/package-management-security-on-opensuse/index.html
+++ b/2008/07/16/package-management-security-on-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/18/index.html
+++ b/2008/07/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/18/trick-of-the-day-reboot-as-user/index.html
+++ b/2008/07/18/trick-of-the-day-reboot-as-user/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/21/index.html
+++ b/2008/07/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/21/lrl-uk-08-not-the-last/index.html
+++ b/2008/07/21/lrl-uk-08-not-the-last/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/index.html
+++ b/2008/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/07/page/2/index.html
+++ b/2008/07/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/05/index.html
+++ b/2008/08/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/05/opensuse-tv/index.html
+++ b/2008/08/05/opensuse-tv/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/07/gui-with-python-and-libyui/index.html
+++ b/2008/08/07/gui-with-python-and-libyui/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/07/index.html
+++ b/2008/08/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/12/akademy-2008/index.html
+++ b/2008/08/12/akademy-2008/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/12/index.html
+++ b/2008/08/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/13/accessing-the-build-service-from-eclipse/index.html
+++ b/2008/08/13/accessing-the-build-service-from-eclipse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/13/index.html
+++ b/2008/08/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/21/get-readwrite-support-to-external-ntfs-hard-drives/index.html
+++ b/2008/08/21/get-readwrite-support-to-external-ntfs-hard-drives/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/21/index.html
+++ b/2008/08/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/21/opensuse-tv-update/index.html
+++ b/2008/08/21/opensuse-tv-update/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/22/index.html
+++ b/2008/08/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/22/linux-distribution-popularity-across-the-globe/index.html
+++ b/2008/08/22/linux-distribution-popularity-across-the-globe/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/26/build-for-another-system/index.html
+++ b/2008/08/26/build-for-another-system/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/26/hackweek-day-1-in-nurnberg/index.html
+++ b/2008/08/26/hackweek-day-1-in-nurnberg/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/26/hackweek-iii-day-1-diary-of-an-outsider/index.html
+++ b/2008/08/26/hackweek-iii-day-1-diary-of-an-outsider/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/26/index.html
+++ b/2008/08/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/27/hackweek-unifying-progress-during-installation/index.html
+++ b/2008/08/27/hackweek-unifying-progress-during-installation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/27/hackweek3-create-a-condensed-monospace-font/index.html
+++ b/2008/08/27/hackweek3-create-a-condensed-monospace-font/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="You see it every day, you normally don't think about it, but it is nevertheless important: fonts." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/27/index.html
+++ b/2008/08/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="You see it every day, you normally don't think about it, but it is nevertheless important: fonts." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/28/button-order-in-yast-trying-to-make-peace-with-both-worlds/index.html
+++ b/2008/08/28/button-order-in-yast-trying-to-make-peace-with-both-worlds/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/28/hackweek-days-2-and-3/index.html
+++ b/2008/08/28/hackweek-days-2-and-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/28/hackweek-drawing-the-lower-case-characters/index.html
+++ b/2008/08/28/hackweek-drawing-the-lower-case-characters/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/28/hackweek-iii-day-2-diary-of-an-outsider/index.html
+++ b/2008/08/28/hackweek-iii-day-2-diary-of-an-outsider/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/28/hackweek-iii-day-3-diary-of-an-outsider/index.html
+++ b/2008/08/28/hackweek-iii-day-3-diary-of-an-outsider/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/28/hackweek-visitor/index.html
+++ b/2008/08/28/hackweek-visitor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/28/index.html
+++ b/2008/08/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/29/hackweek-day-4/index.html
+++ b/2008/08/29/hackweek-day-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/29/hackweek-finished-lower-case-letters/index.html
+++ b/2008/08/29/hackweek-finished-lower-case-letters/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/29/hackweek-iii-day-4-diary-of-an-outsider/index.html
+++ b/2008/08/29/hackweek-iii-day-4-diary-of-an-outsider/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/29/index.html
+++ b/2008/08/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/29/openoffice_org-3_0_0_2/index.html
+++ b/2008/08/29/openoffice_org-3_0_0_2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/31/hackweek-day-2-cross-build-with-obs-part-1/index.html
+++ b/2008/08/31/hackweek-day-2-cross-build-with-obs-part-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/31/hello-lizards/index.html
+++ b/2008/08/31/hello-lizards/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/31/index.html
+++ b/2008/08/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/index.html
+++ b/2008/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/page/2/index.html
+++ b/2008/08/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/08/page/3/index.html
+++ b/2008/08/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/01/arm-worker-on-i586-host/index.html
+++ b/2008/09/01/arm-worker-on-i586-host/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/01/hackweek-day-3-cross-build-with-obs-part-2/index.html
+++ b/2008/09/01/hackweek-day-3-cross-build-with-obs-part-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/01/hackweek-iii-day-5-diary-of-an-outsider/index.html
+++ b/2008/09/01/hackweek-iii-day-5-diary-of-an-outsider/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/01/hackweek/index.html
+++ b/2008/09/01/hackweek/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/01/index.html
+++ b/2008/09/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/03/funny-output-for-some/index.html
+++ b/2008/09/03/funny-output-for-some/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/03/index.html
+++ b/2008/09/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/03/unifying-progress-during-installation-continued/index.html
+++ b/2008/09/03/unifying-progress-during-installation-continued/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/04/google-chrome-on-opensuse/index.html
+++ b/2008/09/04/google-chrome-on-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/04/index.html
+++ b/2008/09/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/06/how-to-remove-the-annoying-kde-error-kio_media_mounthelper-when-unmounting-usb-device/index.html
+++ b/2008/09/06/how-to-remove-the-annoying-kde-error-kio_media_mounthelper-when-unmounting-usb-device/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/06/index.html
+++ b/2008/09/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/06/lizards-howto-for-blogger/index.html
+++ b/2008/09/06/lizards-howto-for-blogger/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/06/opensuse-board-election-comments/index.html
+++ b/2008/09/06/opensuse-board-election-comments/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/07/index.html
+++ b/2008/09/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/07/opensuse-tutorials-is-up-online/index.html
+++ b/2008/09/07/opensuse-tutorials-is-up-online/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/08/index.html
+++ b/2008/09/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/08/opensuse-build-service-build-checks/index.html
+++ b/2008/09/08/opensuse-build-service-build-checks/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/08/small-qt-based-mail-biff/index.html
+++ b/2008/09/08/small-qt-based-mail-biff/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/10/index.html
+++ b/2008/09/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/10/kde3-and-kde4-for-opensuse/index.html
+++ b/2008/09/10/kde3-and-kde4-for-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/10/opensuse-buildservice-cross-build-with-obs-part-3/index.html
+++ b/2008/09/10/opensuse-buildservice-cross-build-with-obs-part-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/11/index.html
+++ b/2008/09/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/11/ydialogspy-an-interactive-yast-dialog-debugger/index.html
+++ b/2008/09/11/ydialogspy-an-interactive-yast-dialog-debugger/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/12/conditional-features-aka-use-flags/index.html
+++ b/2008/09/12/conditional-features-aka-use-flags/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/12/index.html
+++ b/2008/09/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/12/installation-over-serial-line/index.html
+++ b/2008/09/12/installation-over-serial-line/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/12/learning-yast-ycp-language/index.html
+++ b/2008/09/12/learning-yast-ycp-language/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/12/openoffice_org-3_0_0_3_1/index.html
+++ b/2008/09/12/openoffice_org-3_0_0_3_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/12/ydialogspy-can-now-show-widget-properties/index.html
+++ b/2008/09/12/ydialogspy-can-now-show-widget-properties/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/14/developing-with-libyuilibzypp-python-part1/index.html
+++ b/2008/09/14/developing-with-libyuilibzypp-python-part1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/14/index.html
+++ b/2008/09/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/15/index.html
+++ b/2008/09/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/15/my-switch-from-windows-to-linux/index.html
+++ b/2008/09/15/my-switch-from-windows-to-linux/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/16/index.html
+++ b/2008/09/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/16/introductions/index.html
+++ b/2008/09/16/introductions/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/17/160hrs-till-notifications-and-applications-close/index.html
+++ b/2008/09/17/160hrs-till-notifications-and-applications-close/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/17/index.html
+++ b/2008/09/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/18/index.html
+++ b/2008/09/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/18/opensuse-gnome-wiki-cleanup/index.html
+++ b/2008/09/18/opensuse-gnome-wiki-cleanup/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/21/index.html
+++ b/2008/09/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/21/opensuse-nicaragua-in-software-freedom-day/index.html
+++ b/2008/09/21/opensuse-nicaragua-in-software-freedom-day/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/22/index.html
+++ b/2008/09/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/22/opensuse-111-beta-1-installer-screenshots/index.html
+++ b/2008/09/22/opensuse-111-beta-1-installer-screenshots/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/23/brain-transplant/index.html
+++ b/2008/09/23/brain-transplant/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/23/developing-with-libyuilibzypp-python-part2/index.html
+++ b/2008/09/23/developing-with-libyuilibzypp-python-part2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/23/final-reminder/index.html
+++ b/2008/09/23/final-reminder/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/23/index.html
+++ b/2008/09/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/24/astronomy-and-opensuse-in-sfd-nicaragua/index.html
+++ b/2008/09/24/astronomy-and-opensuse-in-sfd-nicaragua/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/24/index.html
+++ b/2008/09/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/24/late-opensuse-gnome-wiki-reminder/index.html
+++ b/2008/09/24/late-opensuse-gnome-wiki-reminder/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/24/openoffice_org-3_0_0_3_2/index.html
+++ b/2008/09/24/openoffice_org-3_0_0_3_2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/24/software-management-as-a-service/index.html
+++ b/2008/09/24/software-management-as-a-service/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/24/wiki-meeting-summary/index.html
+++ b/2008/09/24/wiki-meeting-summary/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/25/index.html
+++ b/2008/09/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/25/opensuse-membership-applications/index.html
+++ b/2008/09/25/opensuse-membership-applications/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/26/how-many-lizards-does-it-takes/index.html
+++ b/2008/09/26/how-many-lizards-does-it-takes/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/26/index.html
+++ b/2008/09/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/29/enlightenment-livecd/index.html
+++ b/2008/09/29/enlightenment-livecd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/29/index.html
+++ b/2008/09/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/30/index.html
+++ b/2008/09/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/30/opensuse-spokespersonlizardevangelistcoordinator/index.html
+++ b/2008/09/30/opensuse-spokespersonlizardevangelistcoordinator/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/index.html
+++ b/2008/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/page/2/index.html
+++ b/2008/09/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/page/3/index.html
+++ b/2008/09/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/09/page/4/index.html
+++ b/2008/09/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/01/good-news-for-russian-opensuse-users/index.html
+++ b/2008/10/01/good-news-for-russian-opensuse-users/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/01/index.html
+++ b/2008/10/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/03/developing-with-libyuilibzypp-python-part3/index.html
+++ b/2008/10/03/developing-with-libyuilibzypp-python-part3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/03/index.html
+++ b/2008/10/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/04/index.html
+++ b/2008/10/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/04/opensuse-buildservice-cross-build/index.html
+++ b/2008/10/04/opensuse-buildservice-cross-build/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/05/index.html
+++ b/2008/10/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/05/opensuse-weekly-news-now-in-russian/index.html
+++ b/2008/10/05/opensuse-weekly-news-now-in-russian/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/06/index.html
+++ b/2008/10/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/06/parralel-processing-in-zypper/index.html
+++ b/2008/10/06/parralel-processing-in-zypper/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/06/zypper-best-feature/index.html
+++ b/2008/10/06/zypper-best-feature/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/07/geekos-scary-movie/index.html
+++ b/2008/10/07/geekos-scary-movie/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/07/index.html
+++ b/2008/10/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/08/index.html
+++ b/2008/10/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/08/last-day-for-granting-franchise-votes/index.html
+++ b/2008/10/08/last-day-for-granting-franchise-votes/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/08/retiring-from-the-opensuse-board/index.html
+++ b/2008/10/08/retiring-from-the-opensuse-board/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/09/index.html
+++ b/2008/10/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/09/openoffice_org-3_0_0_3_4/index.html
+++ b/2008/10/09/openoffice_org-3_0_0_3_4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/09/opensuse-board-election-campaign-for-pascal-bleser/index.html
+++ b/2008/10/09/opensuse-board-election-campaign-for-pascal-bleser/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/09/pagerank-6-for-indonesian-opensuse-community-website/index.html
+++ b/2008/10/09/pagerank-6-for-indonesian-opensuse-community-website/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/11/index.html
+++ b/2008/10/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/11/zimbra-mail-server-how-to-make-an-archive-for-every-incoming-outgoing-mail/index.html
+++ b/2008/10/11/zimbra-mail-server-how-to-make-an-archive-for-every-incoming-outgoing-mail/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/16/index.html
+++ b/2008/10/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/16/new-hardware-for-the-obs/index.html
+++ b/2008/10/16/new-hardware-for-the-obs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/16/remastering-opensuse-how-to-build-your-own-opensuse-based-distro/index.html
+++ b/2008/10/16/remastering-opensuse-how-to-build-your-own-opensuse-based-distro/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/17/10-things/index.html
+++ b/2008/10/17/10-things/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/17/index.html
+++ b/2008/10/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/21/cast-your-vote/index.html
+++ b/2008/10/21/cast-your-vote/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/21/index.html
+++ b/2008/10/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/22/index.html
+++ b/2008/10/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/22/why-do-we-release-opensuse-on-thursdays-or-why-do-we-slip/index.html
+++ b/2008/10/22/why-do-we-release-opensuse-on-thursdays-or-why-do-we-slip/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/24/index.html
+++ b/2008/10/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/24/kde-4-hiding-of-task-bar-is-now-part-of-opensuse-111/index.html
+++ b/2008/10/24/kde-4-hiding-of-task-bar-is-now-part-of-opensuse-111/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/26/index.html
+++ b/2008/10/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/26/kiwi-ltsp-at-the-brindisis-linux-day-italy/index.html
+++ b/2008/10/26/kiwi-ltsp-at-the-brindisis-linux-day-italy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/28/followup-10-things/index.html
+++ b/2008/10/28/followup-10-things/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/28/index.html
+++ b/2008/10/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/30/how-survive-zypper-dup-on-system-with-bad-internet-connection/index.html
+++ b/2008/10/30/how-survive-zypper-dup-on-system-with-bad-internet-connection/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/30/index.html
+++ b/2008/10/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/30/openoffice_org-3_0_0_3_5/index.html
+++ b/2008/10/30/openoffice_org-3_0_0_3_5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/index.html
+++ b/2008/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/page/2/index.html
+++ b/2008/10/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/10/page/3/index.html
+++ b/2008/10/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/06/bootloader-gets-chattier/index.html
+++ b/2008/11/06/bootloader-gets-chattier/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/06/follow-the-netbook-road/index.html
+++ b/2008/11/06/follow-the-netbook-road/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/06/index.html
+++ b/2008/11/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/06/what-to-do-if-every-kernel-update-break-your-bootloader-settings/index.html
+++ b/2008/11/06/what-to-do-if-every-kernel-update-break-your-bootloader-settings/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/07/index.html
+++ b/2008/11/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/07/yast-releases-independent-of-opensuse-releases/index.html
+++ b/2008/11/07/yast-releases-independent-of-opensuse-releases/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/11/developing-with-libyuilibzypp-python-part4/index.html
+++ b/2008/11/11/developing-with-libyuilibzypp-python-part4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/11/index.html
+++ b/2008/11/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/17/index.html
+++ b/2008/11/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/17/updated-python-turbogears-to-107/index.html
+++ b/2008/11/17/updated-python-turbogears-to-107/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/18/arm-support-for-opensuse-buildservice-and-opensuse/index.html
+++ b/2008/11/18/arm-support-for-opensuse-buildservice-and-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/18/index.html
+++ b/2008/11/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/18/new-software-in-build-service/index.html
+++ b/2008/11/18/new-software-in-build-service/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/27/gnome-backports-on-opensuse/index.html
+++ b/2008/11/27/gnome-backports-on-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/27/index.html
+++ b/2008/11/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/27/test-post/index.html
+++ b/2008/11/27/test-post/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/29/index.html
+++ b/2008/11/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/29/opensuse-education-success-history-opensource-ecdl-in-milan/index.html
+++ b/2008/11/29/opensuse-education-success-history-opensource-ecdl-in-milan/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/30/blog-themes/index.html
+++ b/2008/11/30/blog-themes/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/30/index.html
+++ b/2008/11/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/index.html
+++ b/2008/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/11/page/2/index.html
+++ b/2008/11/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/01/index.html
+++ b/2008/12/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/01/opensuse-fosdem-2009-cfp-started/index.html
+++ b/2008/12/01/opensuse-fosdem-2009-cfp-started/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/01/saschas-backtrace-yabsc-for-builder/index.html
+++ b/2008/12/01/saschas-backtrace-yabsc-for-builder/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/01/smolt-and-opensuse/index.html
+++ b/2008/12/01/smolt-and-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/03/index.html
+++ b/2008/12/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/03/opensuse-111-goes-rc2/index.html
+++ b/2008/12/03/opensuse-111-goes-rc2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/05/gmc-livecds-seek-testers/index.html
+++ b/2008/12/05/gmc-livecds-seek-testers/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/05/index.html
+++ b/2008/12/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/07/index.html
+++ b/2008/12/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/07/testing-scratch-the-easy-programming-language/index.html
+++ b/2008/12/07/testing-scratch-the-easy-programming-language/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/10/getting-groupwise-8-client-to-work-on-opensuse-111/index.html
+++ b/2008/12/10/getting-groupwise-8-client-to-work-on-opensuse-111/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/10/index.html
+++ b/2008/12/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/10/setting-up-a-simple-router/index.html
+++ b/2008/12/10/setting-up-a-simple-router/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/11/contrib-repository-kicked-off/index.html
+++ b/2008/12/11/contrib-repository-kicked-off/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/11/index.html
+++ b/2008/12/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/15/index.html
+++ b/2008/12/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/15/longstanding-wiki-problem-fixed/index.html
+++ b/2008/12/15/longstanding-wiki-problem-fixed/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/15/openoffice_org-3_0_0_99_1/index.html
+++ b/2008/12/15/openoffice_org-3_0_0_99_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/16/best-way-to-download-opensuse/index.html
+++ b/2008/12/16/best-way-to-download-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/16/comments-on-phoronix-benchmarking-opensuse-111/index.html
+++ b/2008/12/16/comments-on-phoronix-benchmarking-opensuse-111/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/16/fate-internal-up-and-downstream/index.html
+++ b/2008/12/16/fate-internal-up-and-downstream/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/16/index.html
+++ b/2008/12/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/16/opensuse-mirrorlist-improved/index.html
+++ b/2008/12/16/opensuse-mirrorlist-improved/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/18/index.html
+++ b/2008/12/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/18/what-changed-in-perl-bootloader-between-110-and-111/index.html
+++ b/2008/12/18/what-changed-in-perl-bootloader-between-110-and-111/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/19/index.html
+++ b/2008/12/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/19/opensuse-release-party-in-nurnberg/index.html
+++ b/2008/12/19/opensuse-release-party-in-nurnberg/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/22/for-our-german-people-freiesmagazin/index.html
+++ b/2008/12/22/for-our-german-people-freiesmagazin/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/22/index.html
+++ b/2008/12/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/23/index.html
+++ b/2008/12/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/23/yast-qt4-stylesheet-editor/index.html
+++ b/2008/12/23/yast-qt4-stylesheet-editor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/24/enlightenment-livecd-2/index.html
+++ b/2008/12/24/enlightenment-livecd-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/24/index.html
+++ b/2008/12/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/24/saschas-backtrace-interview-with-petko-d-petkov-on-netsecurify/index.html
+++ b/2008/12/24/saschas-backtrace-interview-with-petko-d-petkov-on-netsecurify/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/27/index.html
+++ b/2008/12/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/27/menage-skype-and-facebook-with-pidgin/index.html
+++ b/2008/12/27/menage-skype-and-facebook-with-pidgin/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/28/index.html
+++ b/2008/12/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/28/saschas-backtrace-gobby-collaborative-editor/index.html
+++ b/2008/12/28/saschas-backtrace-gobby-collaborative-editor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/index.html
+++ b/2008/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/page/2/index.html
+++ b/2008/12/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/12/page/3/index.html
+++ b/2008/12/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/index.html
+++ b/2008/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/10/index.html
+++ b/2008/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/11/index.html
+++ b/2008/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/12/index.html
+++ b/2008/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="You see it every day, you normally don't think about it, but it is nevertheless important: fonts." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/13/index.html
+++ b/2008/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/14/index.html
+++ b/2008/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/15/index.html
+++ b/2008/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/16/index.html
+++ b/2008/page/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/17/index.html
+++ b/2008/page/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/18/index.html
+++ b/2008/page/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/19/index.html
+++ b/2008/page/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/2/index.html
+++ b/2008/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/3/index.html
+++ b/2008/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/4/index.html
+++ b/2008/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/5/index.html
+++ b/2008/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/6/index.html
+++ b/2008/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/7/index.html
+++ b/2008/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/8/index.html
+++ b/2008/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2008/page/9/index.html
+++ b/2008/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/03/howto-adobe-flashplayer-for-x86_64/index.html
+++ b/2009/01/03/howto-adobe-flashplayer-for-x86_64/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/03/index.html
+++ b/2009/01/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/06/index.html
+++ b/2009/01/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/06/osf-status-report-1/index.html
+++ b/2009/01/06/osf-status-report-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/07/index.html
+++ b/2009/01/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/07/new-releases-for-111-in-homesaigkill/index.html
+++ b/2009/01/07/new-releases-for-111-in-homesaigkill/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/07/vote-good-posts/index.html
+++ b/2009/01/07/vote-good-posts/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/08/index.html
+++ b/2009/01/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/08/integration-of-yast-server-modules-to-yast-system-services/index.html
+++ b/2009/01/08/integration-of-yast-server-modules-to-yast-system-services/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/08/kernel-of-the-day-build-service-projects/index.html
+++ b/2009/01/08/kernel-of-the-day-build-service-projects/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/08/rpmlint-wiki-side-overworked/index.html
+++ b/2009/01/08/rpmlint-wiki-side-overworked/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/09/index.html
+++ b/2009/01/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/09/webpin-search-in-yast-for-opensuse-111/index.html
+++ b/2009/01/09/webpin-search-in-yast-for-opensuse-111/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/10/index.html
+++ b/2009/01/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/10/whats-green-red-and-awesome-all-over/index.html
+++ b/2009/01/10/whats-green-red-and-awesome-all-over/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/14/index.html
+++ b/2009/01/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/14/using-ruby-for-system-scripts/index.html
+++ b/2009/01/14/using-ruby-for-system-scripts/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/15/community-content-required/index.html
+++ b/2009/01/15/community-content-required/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/15/index.html
+++ b/2009/01/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/15/opensuse-forums-has-reached-20k-members/index.html
+++ b/2009/01/15/opensuse-forums-has-reached-20k-members/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/16/index.html
+++ b/2009/01/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/16/the-value-of-good-documentation/index.html
+++ b/2009/01/16/the-value-of-good-documentation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/19/graph-of-storage-devices/index.html
+++ b/2009/01/19/graph-of-storage-devices/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/19/index.html
+++ b/2009/01/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/19/modding-the-opensuse-flashlight/index.html
+++ b/2009/01/19/modding-the-opensuse-flashlight/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/19/openoffice_org-3_0_1_0/index.html
+++ b/2009/01/19/openoffice_org-3_0_1_0/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/21/controlling-your-minions-with-ruby-and-capistrano/index.html
+++ b/2009/01/21/controlling-your-minions-with-ruby-and-capistrano/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/21/flashrom-utility-for-linux-part1/index.html
+++ b/2009/01/21/flashrom-utility-for-linux-part1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/21/index.html
+++ b/2009/01/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/21/novell-teaming-on-sles/index.html
+++ b/2009/01/21/novell-teaming-on-sles/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/21/openfate/index.html
+++ b/2009/01/21/openfate/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/23/index.html
+++ b/2009/01/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/23/smolt-popup/index.html
+++ b/2009/01/23/smolt-popup/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/23/tabbed-browsing-for-packages/index.html
+++ b/2009/01/23/tabbed-browsing-for-packages/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/24/automatic-import-calendar-newsopensuseorg-korganizer/index.html
+++ b/2009/01/24/automatic-import-calendar-newsopensuseorg-korganizer/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/24/index.html
+++ b/2009/01/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/26/100-packages-in-contrib/index.html
+++ b/2009/01/26/100-packages-in-contrib/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/26/index.html
+++ b/2009/01/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/27/build-maemo-apps-with-opensuse-buildservice-it-works/index.html
+++ b/2009/01/27/build-maemo-apps-with-opensuse-buildservice-it-works/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/27/index.html
+++ b/2009/01/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/27/tabbed-browsing-for-packages-follow-up/index.html
+++ b/2009/01/27/tabbed-browsing-for-packages-follow-up/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/27/writing-wrapper-packages-for-server-applications-or-a-generic-yast-module/index.html
+++ b/2009/01/27/writing-wrapper-packages-for-server-applications-or-a-generic-yast-module/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/index.html
+++ b/2009/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/page/2/index.html
+++ b/2009/01/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/01/page/3/index.html
+++ b/2009/01/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/03/do-you-want-multiple-kernels-on-your-system/index.html
+++ b/2009/02/03/do-you-want-multiple-kernels-on-your-system/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/03/index.html
+++ b/2009/02/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/03/yast-web/index.html
+++ b/2009/02/03/yast-web/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/04/application-icons-in-the-package-selector/index.html
+++ b/2009/02/04/application-icons-in-the-package-selector/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/04/index.html
+++ b/2009/02/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/05/index.html
+++ b/2009/02/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/05/opensuse-gnome-team-meeting-today-timeshift-05-feb-2009-2200-utc/index.html
+++ b/2009/02/05/opensuse-gnome-team-meeting-today-timeshift-05-feb-2009-2200-utc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/05/osf-status-report-2/index.html
+++ b/2009/02/05/osf-status-report-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/05/thats-how-i-roll-installing-ruby-on-rails-on-opensuse/index.html
+++ b/2009/02/05/thats-how-i-roll-installing-ruby-on-rails-on-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/06/index.html
+++ b/2009/02/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/06/linking-buildservice-packages-with-exact-revisions/index.html
+++ b/2009/02/06/linking-buildservice-packages-with-exact-revisions/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/06/registering-your-shiny-new-hp-mini-note-2133/index.html
+++ b/2009/02/06/registering-your-shiny-new-hp-mini-note-2133/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/09/index.html
+++ b/2009/02/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/09/usb-evdo-alltel-um175al-under-sled-10/index.html
+++ b/2009/02/09/usb-evdo-alltel-um175al-under-sled-10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/10/index.html
+++ b/2009/02/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/10/newupdated-software/index.html
+++ b/2009/02/10/newupdated-software/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/10/openoffice_org-3_0_1_0openoffice_org-3_0_1_2/index.html
+++ b/2009/02/10/openoffice_org-3_0_1_0openoffice_org-3_0_1_2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/11/font-lavoisier/index.html
+++ b/2009/02/11/font-lavoisier/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/11/index.html
+++ b/2009/02/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/11/product-creation-with-the-opensuse-build-service/index.html
+++ b/2009/02/11/product-creation-with-the-opensuse-build-service/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/12/index.html
+++ b/2009/02/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/12/zypper-improved-bash-completion-and-practical-usage/index.html
+++ b/2009/02/12/zypper-improved-bash-completion-and-practical-usage/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/13/index.html
+++ b/2009/02/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/13/writing-first-ycp-program/index.html
+++ b/2009/02/13/writing-first-ycp-program/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/16/index.html
+++ b/2009/02/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/16/why-ant-sucks-somehow/index.html
+++ b/2009/02/16/why-ant-sucks-somehow/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/19/how-developers-see-opensuse/index.html
+++ b/2009/02/19/how-developers-see-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/19/index.html
+++ b/2009/02/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/19/status-russian-mirrors/index.html
+++ b/2009/02/19/status-russian-mirrors/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/19/why-the-buildservice-is-currently-not-for-endusers/index.html
+++ b/2009/02/19/why-the-buildservice-is-currently-not-for-endusers/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/22/index.html
+++ b/2009/02/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/22/opensuse-like-update-repositories-for-third-party-projects/index.html
+++ b/2009/02/22/opensuse-like-update-repositories-for-third-party-projects/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/26/index.html
+++ b/2009/02/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/26/lizardsnewszonkeropensuseorg-updated-to-wordpress-271/index.html
+++ b/2009/02/26/lizardsnewszonkeropensuseorg-updated-to-wordpress-271/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/index.html
+++ b/2009/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/page/2/index.html
+++ b/2009/02/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/02/page/3/index.html
+++ b/2009/02/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/01/index.html
+++ b/2009/03/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/01/low-bandwith-for-opensuse-education/index.html
+++ b/2009/03/01/low-bandwith-for-opensuse-education/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/01/reading-ebooks-with-calibre/index.html
+++ b/2009/03/01/reading-ebooks-with-calibre/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/02/index.html
+++ b/2009/03/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/02/openoffice_org-3_0_99_0/index.html
+++ b/2009/03/02/openoffice_org-3_0_99_0/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/03/index.html
+++ b/2009/03/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/03/osf-status-report-3/index.html
+++ b/2009/03/03/osf-status-report-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/04/index.html
+++ b/2009/03/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/04/newupdated-applications-homesaigkill/index.html
+++ b/2009/03/04/newupdated-applications-homesaigkill/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/06/context-menus-in-yast-partitioner/index.html
+++ b/2009/03/06/context-menus-in-yast-partitioner/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/06/index.html
+++ b/2009/03/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/06/installpython-turbogears2/index.html
+++ b/2009/03/06/installpython-turbogears2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/06/trying-to-bring-russian-community-together/index.html
+++ b/2009/03/06/trying-to-bring-russian-community-together/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/06/yast-qt-ui-with-context-menus/index.html
+++ b/2009/03/06/yast-qt-ui-with-context-menus/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/08/easy-live-upgrade-from-110-to-111/index.html
+++ b/2009/03/08/easy-live-upgrade-from-110-to-111/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/08/index.html
+++ b/2009/03/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/09/index.html
+++ b/2009/03/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/09/trainee-small-project/index.html
+++ b/2009/03/09/trainee-small-project/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/12/index.html
+++ b/2009/03/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/12/nothing-really-special-here/index.html
+++ b/2009/03/12/nothing-really-special-here/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/15/hello-and-apt-repository-decline/index.html
+++ b/2009/03/15/hello-and-apt-repository-decline/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/15/index.html
+++ b/2009/03/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/17/index.html
+++ b/2009/03/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/17/openoffice_org-3_0_99_1/index.html
+++ b/2009/03/17/openoffice_org-3_0_99_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/18/encrypted-root-file-system-on-lvm/index.html
+++ b/2009/03/18/encrypted-root-file-system-on-lvm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/18/index.html
+++ b/2009/03/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/18/personal-note-going-on-paternity-leave/index.html
+++ b/2009/03/18/personal-note-going-on-paternity-leave/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/24/index.html
+++ b/2009/03/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/24/weeklynewstuxradiode/index.html
+++ b/2009/03/24/weeklynewstuxradiode/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/25/index.html
+++ b/2009/03/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/25/openoffice_org-3_0_99_2/index.html
+++ b/2009/03/25/openoffice_org-3_0_99_2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/28/day-saturday-28-2009/index.html
+++ b/2009/03/28/day-saturday-28-2009/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/28/index.html
+++ b/2009/03/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/31/happy-birthday-radiotux/index.html
+++ b/2009/03/31/happy-birthday-radiotux/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/31/index.html
+++ b/2009/03/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/index.html
+++ b/2009/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/03/page/2/index.html
+++ b/2009/03/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/01/happy-birthday-radiotux-the-birthday-broadcast-now-online/index.html
+++ b/2009/04/01/happy-birthday-radiotux-the-birthday-broadcast-now-online/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/01/index.html
+++ b/2009/04/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/01/new-yast-web-released-101/index.html
+++ b/2009/04/01/new-yast-web-released-101/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/01/openoffice_org-3_0_99_3/index.html
+++ b/2009/04/01/openoffice_org-3_0_99_3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/01/the-real-antidote-to-conficker/index.html
+++ b/2009/04/01/the-real-antidote-to-conficker/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/01/yast-and-compiz-during-installation/index.html
+++ b/2009/04/01/yast-and-compiz-during-installation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/02/edit-system-on-iso-image/index.html
+++ b/2009/04/02/edit-system-on-iso-image/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/02/index.html
+++ b/2009/04/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/03/index.html
+++ b/2009/04/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/03/the-generation-of-apt-repositories-at-gwdgde-is-going-to-stop/index.html
+++ b/2009/04/03/the-generation-of-apt-repositories-at-gwdgde-is-going-to-stop/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/04/index.html
+++ b/2009/04/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/04/newupdated-apps-homesaigkill/index.html
+++ b/2009/04/04/newupdated-apps-homesaigkill/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/06/index.html
+++ b/2009/04/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/06/user-readable-logging-of-yast-modules/index.html
+++ b/2009/04/06/user-readable-logging-of-yast-modules/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/08/a-week-of-geeko-love/index.html
+++ b/2009/04/08/a-week-of-geeko-love/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/08/index.html
+++ b/2009/04/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/12/index.html
+++ b/2009/04/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/12/problem-with-an-selfmade-dvd-dvd-recorder/index.html
+++ b/2009/04/12/problem-with-an-selfmade-dvd-dvd-recorder/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/12/updated-software-necpp-130cvs20090101/index.html
+++ b/2009/04/12/updated-software-necpp-130cvs20090101/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/15/combine-osc-with-git/index.html
+++ b/2009/04/15/combine-osc-with-git/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/15/index.html
+++ b/2009/04/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/16/better-commit-message-handling-for-osc/index.html
+++ b/2009/04/16/better-commit-message-handling-for-osc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/16/index.html
+++ b/2009/04/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/20/index.html
+++ b/2009/04/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/20/now-out-python-gasp-bleachbit/index.html
+++ b/2009/04/20/now-out-python-gasp-bleachbit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/21/dropbox-on-opensuse-111/index.html
+++ b/2009/04/21/dropbox-on-opensuse-111/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/21/how-to-track-changes-in-packages-osc-vc/index.html
+++ b/2009/04/21/how-to-track-changes-in-packages-osc-vc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/21/index.html
+++ b/2009/04/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/21/openoffice_org-3_0_99_5/index.html
+++ b/2009/04/21/openoffice_org-3_0_99_5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/24/index.html
+++ b/2009/04/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/24/opensuse-education-live-media-including-official-updates/index.html
+++ b/2009/04/24/opensuse-education-live-media-including-official-updates/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/26/arm-support-for-opensuse-buildservice-and-opensuse-status-update/index.html
+++ b/2009/04/26/arm-support-for-opensuse-buildservice-and-opensuse-status-update/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/26/arm-support-in-opensuse-buildservice-currently-broken/index.html
+++ b/2009/04/26/arm-support-in-opensuse-buildservice-currently-broken/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/26/index.html
+++ b/2009/04/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/27/arm-support-in-opensuse-buildservice-fixed/index.html
+++ b/2009/04/27/arm-support-in-opensuse-buildservice-fixed/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/27/index.html
+++ b/2009/04/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/27/opensuse-nicaragua-flisol-2009/index.html
+++ b/2009/04/27/opensuse-nicaragua-flisol-2009/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/27/whats-new-in-112-install-debuginfo-package-by-build-id/index.html
+++ b/2009/04/27/whats-new-in-112-install-debuginfo-package-by-build-id/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/28/index.html
+++ b/2009/04/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/28/now-out-kde4-skrooge-027/index.html
+++ b/2009/04/28/now-out-kde4-skrooge-027/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/28/openoffice_org-3_0_99_6/index.html
+++ b/2009/04/28/openoffice_org-3_0_99_6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/28/whats-behind-lzma-compressed-livecds/index.html
+++ b/2009/04/28/whats-behind-lzma-compressed-livecds/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/29/index.html
+++ b/2009/04/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/29/openoffice_org-3_0_99_6-localizations/index.html
+++ b/2009/04/29/openoffice_org-3_0_99_6-localizations/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/29/ruby-style-method-injection-in-python/index.html
+++ b/2009/04/29/ruby-style-method-injection-in-python/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/30/index.html
+++ b/2009/04/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/30/swine-flu/index.html
+++ b/2009/04/30/swine-flu/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/index.html
+++ b/2009/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/page/2/index.html
+++ b/2009/04/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/04/page/3/index.html
+++ b/2009/04/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/02/index.html
+++ b/2009/05/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/02/modified-versions-out/index.html
+++ b/2009/05/02/modified-versions-out/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/04/factory-usb-images/index.html
+++ b/2009/05/04/factory-usb-images/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/04/gsoc-introduction-opensusearm/index.html
+++ b/2009/05/04/gsoc-introduction-opensusearm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/04/index.html
+++ b/2009/05/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/04/supressing-keyboardinterrupt-traceback-in-python/index.html
+++ b/2009/05/04/supressing-keyboardinterrupt-traceback-in-python/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/05/index.html
+++ b/2009/05/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/05/openoffice_org-3_0_99_7/index.html
+++ b/2009/05/05/openoffice_org-3_0_99_7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/05/opensuse-gnome-bugday/index.html
+++ b/2009/05/05/opensuse-gnome-bugday/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/06/i-got-network/index.html
+++ b/2009/05/06/i-got-network/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/06/index.html
+++ b/2009/05/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/06/profiled-live-cds/index.html
+++ b/2009/05/06/profiled-live-cds/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/06/rebooting-icecream/index.html
+++ b/2009/05/06/rebooting-icecream/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/07/index.html
+++ b/2009/05/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/07/kolab-on-its-way-back/index.html
+++ b/2009/05/07/kolab-on-its-way-back/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/07/qemu-network-speed/index.html
+++ b/2009/05/07/qemu-network-speed/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/10/index.html
+++ b/2009/05/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/10/kraft-032-released/index.html
+++ b/2009/05/10/kraft-032-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/11/index.html
+++ b/2009/05/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/11/openoffice_org-3_1_0_0/index.html
+++ b/2009/05/11/openoffice_org-3_1_0_0/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/13/congreso-centroamericano-de-software-libre/index.html
+++ b/2009/05/13/congreso-centroamericano-de-software-libre/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/13/index.html
+++ b/2009/05/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/13/opensuse-weekly-news-how-to-make-a-newsletter/index.html
+++ b/2009/05/13/opensuse-weekly-news-how-to-make-a-newsletter/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/13/today-in-factory-a-smart-gdb/index.html
+++ b/2009/05/13/today-in-factory-a-smart-gdb/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/14/index.html
+++ b/2009/05/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/14/join-us-translating-the-special-edition/index.html
+++ b/2009/05/14/join-us-translating-the-special-edition/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/14/new-look-opensuse-education/index.html
+++ b/2009/05/14/new-look-opensuse-education/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/14/opensuse-gnome-bugday-community-effort/index.html
+++ b/2009/05/14/opensuse-gnome-bugday-community-effort/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/14/ruby-on-rails-ajax-and-memory-watching/index.html
+++ b/2009/05/14/ruby-on-rails-ajax-and-memory-watching/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/15/cat-usrlocalbinosc/index.html
+++ b/2009/05/15/cat-usrlocalbinosc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/15/gsoc-integrating-oauth-into-the-opensuse-buildservice/index.html
+++ b/2009/05/15/gsoc-integrating-oauth-into-the-opensuse-buildservice/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/15/index.html
+++ b/2009/05/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/15/livecd-performance-clicfs-vs-squashfs/index.html
+++ b/2009/05/15/livecd-performance-clicfs-vs-squashfs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/15/networkmanager-and-keyring/index.html
+++ b/2009/05/15/networkmanager-and-keyring/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/16/a-quick-tour-of-gnome-shell/index.html
+++ b/2009/05/16/a-quick-tour-of-gnome-shell/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/16/index.html
+++ b/2009/05/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/18/index.html
+++ b/2009/05/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/18/openoffice_org-3_1_0_1/index.html
+++ b/2009/05/18/openoffice_org-3_1_0_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/18/opensuse-gnome-bugday-weekend-wrapup/index.html
+++ b/2009/05/18/opensuse-gnome-bugday-weekend-wrapup/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/20/index.html
+++ b/2009/05/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/20/new-blogger-james-a-tremblay-aka-the-sleducator/index.html
+++ b/2009/05/20/new-blogger-james-a-tremblay-aka-the-sleducator/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/21/gsoc-summary-of-this-weeks-meeting/index.html
+++ b/2009/05/21/gsoc-summary-of-this-weeks-meeting/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/21/index.html
+++ b/2009/05/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/21/searching-for-stories-from-the-opensuse-weekly-news/index.html
+++ b/2009/05/21/searching-for-stories-from-the-opensuse-weekly-news/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/23/index.html
+++ b/2009/05/23/index.html
@@ -23,15 +23,10 @@
 Working together with many people from different areas of interest - but all with focus on schools and education - needs good and extensive communication to get all "on board driving in nearly one direction". The community week helped us to communicate in our IRC channel and coordinate our effords." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/23/my-opensuse-education-community-week-report/index.html
+++ b/2009/05/23/my-opensuse-education-community-week-report/index.html
@@ -23,15 +23,10 @@
 Working together with many people from different areas of interest - but all with focus on schools and education - needs good and extensive communication to get all "on board driving in nearly one direction". The community week helped us to communicate in our IRC channel and coordinate our effords." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/25/extended-deadline-opensuse-conference-2009/index.html
+++ b/2009/05/25/extended-deadline-opensuse-conference-2009/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/25/index.html
+++ b/2009/05/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/25/openoffice_org-3_1_0_4/index.html
+++ b/2009/05/25/openoffice_org-3_1_0_4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/26/index.html
+++ b/2009/05/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/26/opensuse-half-day-unan-june-12/index.html
+++ b/2009/05/26/opensuse-half-day-unan-june-12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/26/time-to-say-goodbye/index.html
+++ b/2009/05/26/time-to-say-goodbye/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/27/fomit-all-instructions/index.html
+++ b/2009/05/27/fomit-all-instructions/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/27/index.html
+++ b/2009/05/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/29/gsoc-summary-of-this-weeks-meeting-2/index.html
+++ b/2009/05/29/gsoc-summary-of-this-weeks-meeting-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/29/index.html
+++ b/2009/05/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/29/opensuse-112-m2-gnome/index.html
+++ b/2009/05/29/opensuse-112-m2-gnome/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/30/index.html
+++ b/2009/05/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/30/opensuse-edu-looks-pretty-too/index.html
+++ b/2009/05/30/opensuse-edu-looks-pretty-too/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/30/opensusearmgsoc-weekly-status/index.html
+++ b/2009/05/30/opensusearmgsoc-weekly-status/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/index.html
+++ b/2009/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/page/2/index.html
+++ b/2009/05/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/page/3/index.html
+++ b/2009/05/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/05/page/4/index.html
+++ b/2009/05/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/01/index.html
+++ b/2009/06/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/01/newupdated-versions/index.html
+++ b/2009/06/01/newupdated-versions/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/01/write-your-own-novelties/index.html
+++ b/2009/06/01/write-your-own-novelties/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/02/coming-soon-on-the-servers-near-you-easy-ltsp-ng/index.html
+++ b/2009/06/02/coming-soon-on-the-servers-near-you-easy-ltsp-ng/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/02/hermes-hack-session/index.html
+++ b/2009/06/02/hermes-hack-session/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/02/index.html
+++ b/2009/06/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/03/call-for-contribution-linuxtag-radiotux/index.html
+++ b/2009/06/03/call-for-contribution-linuxtag-radiotux/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/03/index.html
+++ b/2009/06/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/03/openoffice_org-3_1_0_6-final/index.html
+++ b/2009/06/03/openoffice_org-3_1_0_6-final/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/03/sending-proxy-settings-via-dhcp/index.html
+++ b/2009/06/03/sending-proxy-settings-via-dhcp/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/03/universal-go-oo-3_1/index.html
+++ b/2009/06/03/universal-go-oo-3_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/04/index.html
+++ b/2009/06/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/04/netbeans-65-is-going-to-factory/index.html
+++ b/2009/06/04/netbeans-65-is-going-to-factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/05/gsoc-summary-of-this-weeks-meeting-3/index.html
+++ b/2009/06/05/gsoc-summary-of-this-weeks-meeting-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/05/index.html
+++ b/2009/06/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/05/kraft-032-live-cd/index.html
+++ b/2009/06/05/kraft-032-live-cd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/06/index.html
+++ b/2009/06/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/06/opensusearmgsoc-weekly-status-2/index.html
+++ b/2009/06/06/opensusearmgsoc-weekly-status-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/09/first-steps-with-qtkde-programming/index.html
+++ b/2009/06/09/first-steps-with-qtkde-programming/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/09/index.html
+++ b/2009/06/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/09/opensuse-edu/index.html
+++ b/2009/06/09/opensuse-edu/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/11/index.html
+++ b/2009/06/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/11/newupdated-application/index.html
+++ b/2009/06/11/newupdated-application/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/11/transcodingripping-cluster-using-kiwi-ltsp/index.html
+++ b/2009/06/11/transcodingripping-cluster-using-kiwi-ltsp/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/13/index.html
+++ b/2009/06/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/13/opensuse-day-chile-june-18th-2009/index.html
+++ b/2009/06/13/opensuse-day-chile-june-18th-2009/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/14/index.html
+++ b/2009/06/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/14/promoting-opensuse-edu-li-f-e/index.html
+++ b/2009/06/14/promoting-opensuse-edu-li-f-e/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/15/index.html
+++ b/2009/06/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/15/indian-government-takes-a-lead-in-getting-foss-in-education/index.html
+++ b/2009/06/15/indian-government-takes-a-lead-in-getting-foss-in-education/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/15/obs-education-questions-specific-to-opensuse-education-development-bugs-enhancements-etc/index.html
+++ b/2009/06/15/obs-education-questions-specific-to-opensuse-education-development-bugs-enhancements-etc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/15/south-east-linux-fest/index.html
+++ b/2009/06/15/south-east-linux-fest/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/16/index.html
+++ b/2009/06/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/16/opensusearmgsoc-cross-compilation-speedup/index.html
+++ b/2009/06/16/opensusearmgsoc-cross-compilation-speedup/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/16/quality-checking-the-opensuse-wiki/index.html
+++ b/2009/06/16/quality-checking-the-opensuse-wiki/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/17/cutting-edge-ltsp/index.html
+++ b/2009/06/17/cutting-edge-ltsp/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/17/index.html
+++ b/2009/06/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/18/gsoc-summary-of-this-weeks-meeting-4/index.html
+++ b/2009/06/18/gsoc-summary-of-this-weeks-meeting-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/18/index.html
+++ b/2009/06/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/18/open-source-xml-editor-in-sight/index.html
+++ b/2009/06/18/open-source-xml-editor-in-sight/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/18/openoffice_org-3_1_0_98_1/index.html
+++ b/2009/06/18/openoffice_org-3_1_0_98_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/19/call-for-contribution-opensuse-weekly-news/index.html
+++ b/2009/06/19/call-for-contribution-opensuse-weekly-news/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/19/index.html
+++ b/2009/06/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/20/index.html
+++ b/2009/06/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/20/opensuse-factory-fixing-packages/index.html
+++ b/2009/06/20/opensuse-factory-fixing-packages/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/22/index.html
+++ b/2009/06/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/22/stop-ssh-brute-force-attack-using-susefirewall/index.html
+++ b/2009/06/22/stop-ssh-brute-force-attack-using-susefirewall/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/22/suse-out-your-tweets/index.html
+++ b/2009/06/22/suse-out-your-tweets/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/24/index.html
+++ b/2009/06/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/24/on-kde43/index.html
+++ b/2009/06/24/on-kde43/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/25/index.html
+++ b/2009/06/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/25/installation-resizing-windows-before-proposing-linux-partitions/index.html
+++ b/2009/06/25/installation-resizing-windows-before-proposing-linux-partitions/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/26/gsoc-summary-of-this-weeks-meeting-5/index.html
+++ b/2009/06/26/gsoc-summary-of-this-weeks-meeting-5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/26/index.html
+++ b/2009/06/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/26/on-kontact/index.html
+++ b/2009/06/26/on-kontact/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/26/opensuse-day-at-the-linuxtag/index.html
+++ b/2009/06/26/opensuse-day-at-the-linuxtag/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/28/index.html
+++ b/2009/06/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/28/opensuse-day-chile-awesome/index.html
+++ b/2009/06/28/opensuse-day-chile-awesome/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/29/index.html
+++ b/2009/06/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/29/linuxtag-2009-in-berlin/index.html
+++ b/2009/06/29/linuxtag-2009-in-berlin/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/index.html
+++ b/2009/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/page/2/index.html
+++ b/2009/06/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/page/3/index.html
+++ b/2009/06/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/06/page/4/index.html
+++ b/2009/06/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/01/index.html
+++ b/2009/07/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/01/opensuse-li-f-e-sweetened-by-sugar/index.html
+++ b/2009/07/01/opensuse-li-f-e-sweetened-by-sugar/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/02/howto-how-to-create-an-userpage/index.html
+++ b/2009/07/02/howto-how-to-create-an-userpage/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/02/index.html
+++ b/2009/07/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/02/openoffice_org-3_1_0_98_2/index.html
+++ b/2009/07/02/openoffice_org-3_1_0_98_2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/07/index.html
+++ b/2009/07/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/07/on-wlan-and-browser-authenticated-internet/index.html
+++ b/2009/07/07/on-wlan-and-browser-authenticated-internet/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/10/1453/index.html
+++ b/2009/07/10/1453/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/10/index.html
+++ b/2009/07/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/11/index.html
+++ b/2009/07/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/11/lightweight-x11-desktop-environment-aka-lxde/index.html
+++ b/2009/07/11/lightweight-x11-desktop-environment-aka-lxde/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/13/index.html
+++ b/2009/07/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="To make suspend to disk work with an encrypted root file system and swap on lvm on luks, add "luks" to the "#%depends:" line in /lib/mkinitrd/scripts/boot-lvm2.sh and recreate the initial ramdisk." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/13/official-x11lxde-project-now-open-we-need-you/index.html
+++ b/2009/07/13/official-x11lxde-project-now-open-we-need-you/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/13/suspend-to-disk-with-encrypted-root-file-system-on-lvm/index.html
+++ b/2009/07/13/suspend-to-disk-with-encrypted-root-file-system-on-lvm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="To make suspend to disk work with an encrypted root file system and swap on lvm on luks, add "luks" to the "#%depends:" line in /lib/mkinitrd/scripts/boot-lvm2.sh and recreate the initial ramdisk." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/14/index.html
+++ b/2009/07/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/14/li-f-e-updated/index.html
+++ b/2009/07/14/li-f-e-updated/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/14/reducing-size-of-factory-updates/index.html
+++ b/2009/07/14/reducing-size-of-factory-updates/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/15/index.html
+++ b/2009/07/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/15/package-review-in-the-build-service/index.html
+++ b/2009/07/15/package-review-in-the-build-service/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/15/self-optimization-through-self-awareness/index.html
+++ b/2009/07/15/self-optimization-through-self-awareness/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/16/index.html
+++ b/2009/07/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/16/lydia-pintscher-the-way-to-amarok-22/index.html
+++ b/2009/07/16/lydia-pintscher-the-way-to-amarok-22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/17/index.html
+++ b/2009/07/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/17/lxde-working-on-branding-opensuse/index.html
+++ b/2009/07/17/lxde-working-on-branding-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/17/updated-package-bleachbit/index.html
+++ b/2009/07/17/updated-package-bleachbit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/19/howto-regular-cleanup-the-tempfolders/index.html
+++ b/2009/07/19/howto-regular-cleanup-the-tempfolders/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/19/index.html
+++ b/2009/07/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/20/hackweek-application-directory-interface-for-obs/index.html
+++ b/2009/07/20/hackweek-application-directory-interface-for-obs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/20/index.html
+++ b/2009/07/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/20/introducing-libstorage/index.html
+++ b/2009/07/20/introducing-libstorage/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/20/new-package-kpassgen/index.html
+++ b/2009/07/20/new-package-kpassgen/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/21/index.html
+++ b/2009/07/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/21/solar-eclipse-on-your-desktop/index.html
+++ b/2009/07/21/solar-eclipse-on-your-desktop/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/21/some-impressions-from-hackweek/index.html
+++ b/2009/07/21/some-impressions-from-hackweek/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/23/further-hackweek-iv-impressions/index.html
+++ b/2009/07/23/further-hackweek-iv-impressions/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/23/index.html
+++ b/2009/07/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/23/ullae-veliyae-hackweek/index.html
+++ b/2009/07/23/ullae-veliyae-hackweek/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="The hackweek project I worked to create a live graphing utility that displays I/O of processes. Screen-shots, RPM download link, project homepage link,..." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/23/updated-package-kpassgen-02/index.html
+++ b/2009/07/23/updated-package-kpassgen-02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/24/build-service-for-package-testing-and-making-factory-updates-smaller/index.html
+++ b/2009/07/24/build-service-for-package-testing-and-making-factory-updates-smaller/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/24/call-for-opensuse-core-test-team/index.html
+++ b/2009/07/24/call-for-opensuse-core-test-team/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/24/gsoc-summary-of-this-weeks-meeting-6/index.html
+++ b/2009/07/24/gsoc-summary-of-this-weeks-meeting-6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/24/index.html
+++ b/2009/07/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/27/index.html
+++ b/2009/07/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/27/openoffice_org-3_1_0_99_1/index.html
+++ b/2009/07/27/openoffice_org-3_1_0_99_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/28/fresh-fruity/index.html
+++ b/2009/07/28/fresh-fruity/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/28/index.html
+++ b/2009/07/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/28/suse-studio-launch-and-opensuse/index.html
+++ b/2009/07/28/suse-studio-launch-and-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/29/hackweek-iv-novell-bugzilla-access-from-command-line/index.html
+++ b/2009/07/29/hackweek-iv-novell-bugzilla-access-from-command-line/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/29/improved-mirror-selection-for-india/index.html
+++ b/2009/07/29/improved-mirror-selection-for-india/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/29/index.html
+++ b/2009/07/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/30/index.html
+++ b/2009/07/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/30/new-package-association-subscribers-manager-30/index.html
+++ b/2009/07/30/new-package-association-subscribers-manager-30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/30/testing-packages-and-their-dependencies/index.html
+++ b/2009/07/30/testing-packages-and-their-dependencies/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/31/index.html
+++ b/2009/07/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/31/openfate-feature-306967-kde-default/index.html
+++ b/2009/07/31/openfate-feature-306967-kde-default/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/31/small-opensuse-build-service-tips/index.html
+++ b/2009/07/31/small-opensuse-build-service-tips/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/index.html
+++ b/2009/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/page/2/index.html
+++ b/2009/07/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/page/3/index.html
+++ b/2009/07/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/07/page/4/index.html
+++ b/2009/07/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/03/index.html
+++ b/2009/08/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/03/li-f-e-and-kiwi-ltsp-updates/index.html
+++ b/2009/08/03/li-f-e-and-kiwi-ltsp-updates/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/03/smarter-osc-commit/index.html
+++ b/2009/08/03/smarter-osc-commit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/03/source-services-001-no-more-writing-spec-files/index.html
+++ b/2009/08/03/source-services-001-no-more-writing-spec-files/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/05/28-partitions-on-a-single-disk/index.html
+++ b/2009/08/05/28-partitions-on-a-single-disk/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/05/hybrid-live-systems/index.html
+++ b/2009/08/05/hybrid-live-systems/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/05/index.html
+++ b/2009/08/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/05/the-desktop-dingdong/index.html
+++ b/2009/08/05/the-desktop-dingdong/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/06/index.html
+++ b/2009/08/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/06/with-gsoc-almost-over/index.html
+++ b/2009/08/06/with-gsoc-almost-over/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/07/index.html
+++ b/2009/08/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/07/openoffice_org-3_1_0_99_2/index.html
+++ b/2009/08/07/openoffice_org-3_1_0_99_2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/08/comparing-opensuse-112-and-kubuntu-karmic-liveusb-setups/index.html
+++ b/2009/08/08/comparing-opensuse-112-and-kubuntu-karmic-liveusb-setups/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/08/index.html
+++ b/2009/08/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/10/enlightenment-is-coming/index.html
+++ b/2009/08/10/enlightenment-is-coming/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/10/index.html
+++ b/2009/08/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/12/gsoc-summary-of-this-weeks-meeting-7/index.html
+++ b/2009/08/12/gsoc-summary-of-this-weeks-meeting-7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/12/index.html
+++ b/2009/08/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/12/opensusearm-gsoc-status-and-final-spurt/index.html
+++ b/2009/08/12/opensusearm-gsoc-status-and-final-spurt/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/13/cliced-hybrids/index.html
+++ b/2009/08/13/cliced-hybrids/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/13/index.html
+++ b/2009/08/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/13/some-kde-4-tips-you-should-know/index.html
+++ b/2009/08/13/some-kde-4-tips-you-should-know/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/13/twitter-statusupdate-via-cli-shell/index.html
+++ b/2009/08/13/twitter-statusupdate-via-cli-shell/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/14/index.html
+++ b/2009/08/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/14/interview-with-greg-kroah-hartmann/index.html
+++ b/2009/08/14/interview-with-greg-kroah-hartmann/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/16/call-for-participation-opensuse-weekly-news/index.html
+++ b/2009/08/16/call-for-participation-opensuse-weekly-news/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/16/index.html
+++ b/2009/08/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/16/updated-package-kpassgen-0-5/index.html
+++ b/2009/08/16/updated-package-kpassgen-0-5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/19/index.html
+++ b/2009/08/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/19/updated-package-bleachbit-0-6-1/index.html
+++ b/2009/08/19/updated-package-bleachbit-0-6-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/21/index.html
+++ b/2009/08/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/21/openoffice_org-3_1_0_99_3/index.html
+++ b/2009/08/21/openoffice_org-3_1_0_99_3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/22/index.html
+++ b/2009/08/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/22/sending-lots-of-pictures-in-one-message/index.html
+++ b/2009/08/22/sending-lots-of-pictures-in-one-message/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/23/1-click-bug-reporting/index.html
+++ b/2009/08/23/1-click-bug-reporting/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/23/index.html
+++ b/2009/08/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/23/whitepaper-weekly-news-survey-published/index.html
+++ b/2009/08/23/whitepaper-weekly-news-survey-published/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/24/2017/index.html
+++ b/2009/08/24/2017/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/24/index.html
+++ b/2009/08/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/24/lxde-can-do-it-lxde-on-android-smartphone/index.html
+++ b/2009/08/24/lxde-can-do-it-lxde-on-android-smartphone/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/25/index.html
+++ b/2009/08/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/25/workshop-for-bita-members/index.html
+++ b/2009/08/25/workshop-for-bita-members/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/27/clicks-with-touchpad-trick-11-2-m6/index.html
+++ b/2009/08/27/clicks-with-touchpad-trick-11-2-m6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/27/index.html
+++ b/2009/08/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/28/firewall-zone-switcher-updated/index.html
+++ b/2009/08/28/firewall-zone-switcher-updated/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/28/index.html
+++ b/2009/08/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/index.html
+++ b/2009/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/page/2/index.html
+++ b/2009/08/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/08/page/3/index.html
+++ b/2009/08/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/02/building-against-opensusefactory/index.html
+++ b/2009/09/02/building-against-opensusefactory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/02/index.html
+++ b/2009/09/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/02/opensuse-lxde-live-cd-now-ready/index.html
+++ b/2009/09/02/opensuse-lxde-live-cd-now-ready/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/03/hermes-improvements/index.html
+++ b/2009/09/03/hermes-improvements/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/03/index.html
+++ b/2009/09/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/04/index.html
+++ b/2009/09/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/04/openoffice_org-3_1_1_1-final/index.html
+++ b/2009/09/04/openoffice_org-3_1_1_1-final/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/07/index.html
+++ b/2009/09/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/07/made-my-day/index.html
+++ b/2009/09/07/made-my-day/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/08/index.html
+++ b/2009/09/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/08/universal-go-oo-3_1_1/index.html
+++ b/2009/09/08/universal-go-oo-3_1_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/10/index.html
+++ b/2009/09/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/10/software-freedom-day-italy-perugia/index.html
+++ b/2009/09/10/software-freedom-day-italy-perugia/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/11/index.html
+++ b/2009/09/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/11/opensuse-core-test-team-established/index.html
+++ b/2009/09/11/opensuse-core-test-team-established/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/12/11-2-64-bit-and-mp3/index.html
+++ b/2009/09/12/11-2-64-bit-and-mp3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/12/enlightenment-live-cdusb-progress-report/index.html
+++ b/2009/09/12/enlightenment-live-cdusb-progress-report/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/12/index.html
+++ b/2009/09/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/12/lxde-lxdm-and-trash-support/index.html
+++ b/2009/09/12/lxde-lxdm-and-trash-support/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="LXDE" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/13/build-service-intro/index.html
+++ b/2009/09/13/build-service-intro/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/13/index.html
+++ b/2009/09/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/13/opensuse-lxde-live-cd-1-0-0/index.html
+++ b/2009/09/13/opensuse-lxde-live-cd-1-0-0/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/16/index.html
+++ b/2009/09/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/16/opensuse-edu-li-f-e-goes-hybrid/index.html
+++ b/2009/09/16/opensuse-edu-li-f-e-goes-hybrid/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/17/index.html
+++ b/2009/09/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/17/new-layout-in-town/index.html
+++ b/2009/09/17/new-layout-in-town/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/17/opensuse-conference-09-has-started/index.html
+++ b/2009/09/17/opensuse-conference-09-has-started/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/18/index.html
+++ b/2009/09/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/18/osc09-notes-from-governance-session/index.html
+++ b/2009/09/18/osc09-notes-from-governance-session/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/19/index.html
+++ b/2009/09/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/19/opensuse-conference-photos/index.html
+++ b/2009/09/19/opensuse-conference-photos/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/21/docbook-xml-die-zweite/index.html
+++ b/2009/09/21/docbook-xml-die-zweite/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/21/index.html
+++ b/2009/09/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/23/index.html
+++ b/2009/09/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/23/osc09-lightning-talks/index.html
+++ b/2009/09/23/osc09-lightning-talks/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/29/index.html
+++ b/2009/09/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/29/remote-learner-unveils/index.html
+++ b/2009/09/29/remote-learner-unveils/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/30/index.html
+++ b/2009/09/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/30/opensuse-lxde-improvments-to-pcmanfm/index.html
+++ b/2009/09/30/opensuse-lxde-improvments-to-pcmanfm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/index.html
+++ b/2009/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/page/2/index.html
+++ b/2009/09/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/09/page/3/index.html
+++ b/2009/09/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/01/index.html
+++ b/2009/10/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/01/updating-in-place-from-opensuse-11-1-to-11-2/index.html
+++ b/2009/10/01/updating-in-place-from-opensuse-11-1-to-11-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/02/index.html
+++ b/2009/10/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/02/opensuse-ambassadors-numbers/index.html
+++ b/2009/10/02/opensuse-ambassadors-numbers/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/03/index.html
+++ b/2009/10/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/03/opensuse-and-li-f-e-dvds-shipped-on-order/index.html
+++ b/2009/10/03/opensuse-and-li-f-e-dvds-shipped-on-order/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/07/about-patterns-versus-packages/index.html
+++ b/2009/10/07/about-patterns-versus-packages/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/07/index.html
+++ b/2009/10/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/09/index.html
+++ b/2009/10/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/09/making-technology-previews-succeed-osc-09-unconference-session-notes/index.html
+++ b/2009/10/09/making-technology-previews-succeed-osc-09-unconference-session-notes/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/16/index.html
+++ b/2009/10/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/16/speeding-up-opensuse-build-service/index.html
+++ b/2009/10/16/speeding-up-opensuse-build-service/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/18/index.html
+++ b/2009/10/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/18/kolab-becomes-available-again-for-opensuse/index.html
+++ b/2009/10/18/kolab-becomes-available-again-for-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/21/branching-contrib-for-11-2/index.html
+++ b/2009/10/21/branching-contrib-for-11-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/21/i-am-going-to-encuentro-linux-2009/index.html
+++ b/2009/10/21/i-am-going-to-encuentro-linux-2009/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/21/index.html
+++ b/2009/10/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/21/update-from-the-opensuse-boosters/index.html
+++ b/2009/10/21/update-from-the-opensuse-boosters/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/22/developing-for-opensuse-using-devel-projects/index.html
+++ b/2009/10/22/developing-for-opensuse-using-devel-projects/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/22/index.html
+++ b/2009/10/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/27/index.html
+++ b/2009/10/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/27/lange-nacht-der-wissenschaften-is-over/index.html
+++ b/2009/10/27/lange-nacht-der-wissenschaften-is-over/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/28/announcing-candidacy-for-the-opensuse-community-board/index.html
+++ b/2009/10/28/announcing-candidacy-for-the-opensuse-community-board/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/28/index.html
+++ b/2009/10/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/29/index.html
+++ b/2009/10/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/29/pictures-from-you-finger-print-reader/index.html
+++ b/2009/10/29/pictures-from-you-finger-print-reader/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/29/updating-from-factory-to-opensuse-11-2/index.html
+++ b/2009/10/29/updating-from-factory-to-opensuse-11-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/30/a-distro-without-packages/index.html
+++ b/2009/10/30/a-distro-without-packages/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/30/index.html
+++ b/2009/10/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/31/index.html
+++ b/2009/10/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/31/opensuse-edu-li-f-e-t-shirt/index.html
+++ b/2009/10/31/opensuse-edu-li-f-e-t-shirt/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/index.html
+++ b/2009/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/10/page/2/index.html
+++ b/2009/10/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/02/index.html
+++ b/2009/11/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/02/obs-attribute-system/index.html
+++ b/2009/11/02/obs-attribute-system/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/06/booster-sprint-results/index.html
+++ b/2009/11/06/booster-sprint-results/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/06/index.html
+++ b/2009/11/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/06/opensuse-launch-party-in-nurnberg-nov-12/index.html
+++ b/2009/11/06/opensuse-launch-party-in-nurnberg-nov-12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/07/index.html
+++ b/2009/11/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/07/opensuse-edu-li-f-e-at-ifest/index.html
+++ b/2009/11/07/opensuse-edu-li-f-e-at-ifest/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/09/index.html
+++ b/2009/11/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/09/opensuse-11-2-ubuntu-karmic-launch-party-invitation/index.html
+++ b/2009/11/09/opensuse-11-2-ubuntu-karmic-launch-party-invitation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/10/index.html
+++ b/2009/11/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/10/obs-webclient-is-now-able-to-handle-requests/index.html
+++ b/2009/11/10/obs-webclient-is-now-able-to-handle-requests/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/10/openoffice_org-3_1_99_1/index.html
+++ b/2009/11/10/openoffice_org-3_1_99_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/11/index.html
+++ b/2009/11/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/11/linux-launch-party-in-mainstream-press/index.html
+++ b/2009/11/11/linux-launch-party-in-mainstream-press/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/12/index.html
+++ b/2009/11/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/12/opensuse-11-2-is-out/index.html
+++ b/2009/11/12/opensuse-11-2-is-out/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/12/opensuse-11-2-persistent-liveusb-setup/index.html
+++ b/2009/11/12/opensuse-11-2-persistent-liveusb-setup/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/13/index.html
+++ b/2009/11/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/13/opensuse-launch-event-in-nurnberg/index.html
+++ b/2009/11/13/opensuse-launch-event-in-nurnberg/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/14/index.html
+++ b/2009/11/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/14/opensuse-11-2-ubuntu-karmic-launch-party-report/index.html
+++ b/2009/11/14/opensuse-11-2-ubuntu-karmic-launch-party-report/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/15/index.html
+++ b/2009/11/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/15/reiser4-for-opensuse-11-2/index.html
+++ b/2009/11/15/reiser4-for-opensuse-11-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/16/index.html
+++ b/2009/11/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/16/openoffice_org-3_1_99_2/index.html
+++ b/2009/11/16/openoffice_org-3_1_99_2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/17/2009/05/06/profiled-live-cds/index.html
+++ b/2009/11/17/2009/05/06/profiled-live-cds/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/17/index.html
+++ b/2009/11/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/17/opensuse-edu-li-f-e-creating-open-minds/index.html
+++ b/2009/11/17/opensuse-edu-li-f-e-creating-open-minds/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/21/dni-electronico-en-opensuse/index.html
+++ b/2009/11/21/dni-electronico-en-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/21/index.html
+++ b/2009/11/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/23/index.html
+++ b/2009/11/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/23/playing-with-xpath-expressions-in-the-xmllint-shell/index.html
+++ b/2009/11/23/playing-with-xpath-expressions-in-the-xmllint-shell/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/24/index.html
+++ b/2009/11/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/24/report-from-opensuse-11-2-release-party-in-prague/index.html
+++ b/2009/11/24/report-from-opensuse-11-2-release-party-in-prague/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/25/index.html
+++ b/2009/11/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/25/new-pm-utils-for-opensuse/index.html
+++ b/2009/11/25/new-pm-utils-for-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/27/index.html
+++ b/2009/11/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/27/usability-symposium/index.html
+++ b/2009/11/27/usability-symposium/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/30/index.html
+++ b/2009/11/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/30/openoffice_org-3_1_99_3/index.html
+++ b/2009/11/30/openoffice_org-3_1_99_3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/index.html
+++ b/2009/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/page/2/index.html
+++ b/2009/11/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/11/page/3/index.html
+++ b/2009/11/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/03/encrypted-directory/index.html
+++ b/2009/12/03/encrypted-directory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/03/index.html
+++ b/2009/12/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/03/kolab-cyrus-imapd-inherits-from-opensuse-base-cyrus-imapd/index.html
+++ b/2009/12/03/kolab-cyrus-imapd-inherits-from-opensuse-base-cyrus-imapd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/04/index.html
+++ b/2009/12/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/04/openoffice_org-3_1_1_5/index.html
+++ b/2009/12/04/openoffice_org-3_1_1_5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/06/index.html
+++ b/2009/12/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/06/kiwi-relaxng-schema-explained/index.html
+++ b/2009/12/06/kiwi-relaxng-schema-explained/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/08/index.html
+++ b/2009/12/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/08/install-multiple-kernel-versions-using-the-yast-qt-package-manager/index.html
+++ b/2009/12/08/install-multiple-kernel-versions-using-the-yast-qt-package-manager/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/08/opensuse-celebrates-x-mas-in-nurnberg/index.html
+++ b/2009/12/08/opensuse-celebrates-x-mas-in-nurnberg/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/08/opensuse-edu-li-f-e-at-foss-in/index.html
+++ b/2009/12/08/opensuse-edu-li-f-e-at-foss-in/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/09/how-to-activate-flash-plugin-for-google-chrome-on-opensuse-11-2/index.html
+++ b/2009/12/09/how-to-activate-flash-plugin-for-google-chrome-on-opensuse-11-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/09/index.html
+++ b/2009/12/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/14/index.html
+++ b/2009/12/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/14/openoffice_org-3_1_99_4/index.html
+++ b/2009/12/14/openoffice_org-3_1_99_4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/15/2827/index.html
+++ b/2009/12/15/2827/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/15/index.html
+++ b/2009/12/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/19/index.html
+++ b/2009/12/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/19/opensuse-wiki-changes/index.html
+++ b/2009/12/19/opensuse-wiki-changes/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/20/first-post-first-whishes/index.html
+++ b/2009/12/20/first-post-first-whishes/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/20/index.html
+++ b/2009/12/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/22/index.html
+++ b/2009/12/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/22/quick-tip-novell-bugzilla-and-klipper/index.html
+++ b/2009/12/22/quick-tip-novell-bugzilla-and-klipper/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/23/index.html
+++ b/2009/12/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/23/openoffice_org-3_2_0_1/index.html
+++ b/2009/12/23/openoffice_org-3_2_0_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/23/opensuse-build-service-1-7-beta-1/index.html
+++ b/2009/12/23/opensuse-build-service-1-7-beta-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/index.html
+++ b/2009/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/12/page/2/index.html
+++ b/2009/12/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/index.html
+++ b/2009/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/10/index.html
+++ b/2009/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/11/index.html
+++ b/2009/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/12/index.html
+++ b/2009/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/13/index.html
+++ b/2009/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/14/index.html
+++ b/2009/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/15/index.html
+++ b/2009/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/16/index.html
+++ b/2009/page/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/17/index.html
+++ b/2009/page/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/18/index.html
+++ b/2009/page/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/19/index.html
+++ b/2009/page/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/2/index.html
+++ b/2009/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/20/index.html
+++ b/2009/page/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/21/index.html
+++ b/2009/page/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/22/index.html
+++ b/2009/page/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/23/index.html
+++ b/2009/page/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/24/index.html
+++ b/2009/page/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/25/index.html
+++ b/2009/page/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/26/index.html
+++ b/2009/page/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/27/index.html
+++ b/2009/page/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/28/index.html
+++ b/2009/page/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/29/index.html
+++ b/2009/page/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/3/index.html
+++ b/2009/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/30/index.html
+++ b/2009/page/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/31/index.html
+++ b/2009/page/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/32/index.html
+++ b/2009/page/32/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/4/index.html
+++ b/2009/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/5/index.html
+++ b/2009/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/6/index.html
+++ b/2009/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/7/index.html
+++ b/2009/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/8/index.html
+++ b/2009/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2009/page/9/index.html
+++ b/2009/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/04/feed-problems-on-lizardsspotlight-solved/index.html
+++ b/2010/01/04/feed-problems-on-lizardsspotlight-solved/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/04/index.html
+++ b/2010/01/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/04/opensuse-11-2-on-dell-mini-10v/index.html
+++ b/2010/01/04/opensuse-11-2-on-dell-mini-10v/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/08/index.html
+++ b/2010/01/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/08/russian-opensuse-forum/index.html
+++ b/2010/01/08/russian-opensuse-forum/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/11/index.html
+++ b/2010/01/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/11/my-inadvertent-experiment-return/index.html
+++ b/2010/01/11/my-inadvertent-experiment-return/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/11/obs-reports-scheduling-state-now/index.html
+++ b/2010/01/11/obs-reports-scheduling-state-now/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/12/index.html
+++ b/2010/01/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/12/kraft-project-status/index.html
+++ b/2010/01/12/kraft-project-status/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/14/index.html
+++ b/2010/01/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/14/what-a-cool-app-screenie/index.html
+++ b/2010/01/14/what-a-cool-app-screenie/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/15/index.html
+++ b/2010/01/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/15/lxde-mission-almost-accomplished/index.html
+++ b/2010/01/15/lxde-mission-almost-accomplished/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/15/using-kwallet-or-gnome-keyring-with-subversion/index.html
+++ b/2010/01/15/using-kwallet-or-gnome-keyring-with-subversion/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/17/a-stable-repository-for-kolab/index.html
+++ b/2010/01/17/a-stable-repository-for-kolab/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/17/eclipse-and-stellarium/index.html
+++ b/2010/01/17/eclipse-and-stellarium/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/17/index.html
+++ b/2010/01/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/18/index.html
+++ b/2010/01/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/18/openoffice_org-3_2_0_2/index.html
+++ b/2010/01/18/openoffice_org-3_2_0_2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/20/index.html
+++ b/2010/01/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/20/locking-down-gnome-in-suse-11-based-distributions/index.html
+++ b/2010/01/20/locking-down-gnome-in-suse-11-based-distributions/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/21/baroda-it-associationbita-show-2010/index.html
+++ b/2010/01/21/baroda-it-associationbita-show-2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/21/index.html
+++ b/2010/01/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/22/having-trouble-with-vmware-console-your-keyboard-mouse/index.html
+++ b/2010/01/22/having-trouble-with-vmware-console-your-keyboard-mouse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/22/index.html
+++ b/2010/01/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/26/index.html
+++ b/2010/01/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/26/socialising-with-developers-and-communnities/index.html
+++ b/2010/01/26/socialising-with-developers-and-communnities/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/27/hot-off-the-opensuse-build-service-press/index.html
+++ b/2010/01/27/hot-off-the-opensuse-build-service-press/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/27/index.html
+++ b/2010/01/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/29/index.html
+++ b/2010/01/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/29/openoffice_org-3_2_0_4/index.html
+++ b/2010/01/29/openoffice_org-3_2_0_4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/29/tip-transparent-editing-of-gpg-encrypted-files-with-vim/index.html
+++ b/2010/01/29/tip-transparent-editing-of-gpg-encrypted-files-with-vim/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/30/index.html
+++ b/2010/01/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/30/irssi-on-freenode-with-ssl-verification/index.html
+++ b/2010/01/30/irssi-on-freenode-with-ssl-verification/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/index.html
+++ b/2010/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/01/page/2/index.html
+++ b/2010/01/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/01/hermes-twittering-about-opensuse-factory/index.html
+++ b/2010/02/01/hermes-twittering-about-opensuse-factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/01/index.html
+++ b/2010/02/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/07/index.html
+++ b/2010/02/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/07/writing-man-pages/index.html
+++ b/2010/02/07/writing-man-pages/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/08/index.html
+++ b/2010/02/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/08/openoffice_org-3_2_0_5/index.html
+++ b/2010/02/08/openoffice_org-3_2_0_5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/09/cheat-ocfs2-tools/index.html
+++ b/2010/02/09/cheat-ocfs2-tools/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/09/index.html
+++ b/2010/02/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/10/astrogarrobo-beta/index.html
+++ b/2010/02/10/astrogarrobo-beta/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/10/index.html
+++ b/2010/02/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/10/xen-para-virtualized-opensuse-11-2/index.html
+++ b/2010/02/10/xen-para-virtualized-opensuse-11-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/11/index.html
+++ b/2010/02/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/11/new-osc-feature-to-review-requests/index.html
+++ b/2010/02/11/new-osc-feature-to-review-requests/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/11/opensuse-forums-–-tighter-integration-with-the-opensuse-board-2/index.html
+++ b/2010/02/11/opensuse-forums-–-tighter-integration-with-the-opensuse-board-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/12/index.html
+++ b/2010/02/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/12/openoffice_org-3_2_0_5-final/index.html
+++ b/2010/02/12/openoffice_org-3_2_0_5-final/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/12/universal-go-oo-3_2/index.html
+++ b/2010/02/12/universal-go-oo-3_2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/13/fosdem10/index.html
+++ b/2010/02/13/fosdem10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/13/index.html
+++ b/2010/02/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/15/index.html
+++ b/2010/02/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/15/kde-icons-for-apache/index.html
+++ b/2010/02/15/kde-icons-for-apache/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/15/supertuxkart-does-not-start-due-to-pulse-audio/index.html
+++ b/2010/02/15/supertuxkart-does-not-start-due-to-pulse-audio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/16/fosdem-2010-one-week-later/auditorium/index.html
+++ b/2010/02/16/fosdem-2010-one-week-later/auditorium/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Lots of FLOSS people gathered at the past FOSDEM 2010" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/16/fosdem-2010-one-week-later/index.html
+++ b/2010/02/16/fosdem-2010-one-week-later/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/16/fosdem-2010-one-week-later/opensuse2/index.html
+++ b/2010/02/16/fosdem-2010-one-week-later/opensuse2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Lots of attention gathered the openSUSE 11.2 demo at the openSUSE booth at FOSDEM 2010" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/16/index.html
+++ b/2010/02/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/21/index.html
+++ b/2010/02/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/21/kraft-document-templating-system/index.html
+++ b/2010/02/21/kraft-document-templating-system/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/24/index.html
+++ b/2010/02/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/24/opengarrobito-0-1-9-opensuse-multimedia/index.html
+++ b/2010/02/24/opengarrobito-0-1-9-opensuse-multimedia/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/26/cd-tokamak4-make-uninstall-make-clean/index.html
+++ b/2010/02/26/cd-tokamak4-make-uninstall-make-clean/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/26/index.html
+++ b/2010/02/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/26/openoffice_org-3_2_0_7-bugfix/index.html
+++ b/2010/02/26/openoffice_org-3_2_0_7-bugfix/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/26/tokamak4/index.html
+++ b/2010/02/26/tokamak4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/27/index.html
+++ b/2010/02/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/27/kraft-0-40-beta-1-for-kde-4-available/index.html
+++ b/2010/02/27/kraft-0-40-beta-1-for-kde-4-available/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/27/tokamak_4/index.html
+++ b/2010/02/27/tokamak_4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/28/a-green-rock/index.html
+++ b/2010/02/28/a-green-rock/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/28/index.html
+++ b/2010/02/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/index.html
+++ b/2010/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/page/2/index.html
+++ b/2010/02/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/02/page/3/index.html
+++ b/2010/02/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/01/fosdem´10/index.html
+++ b/2010/03/01/fosdem´10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/01/index.html
+++ b/2010/03/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/01/opensuse-google-summer-of-code-2010/index.html
+++ b/2010/03/01/opensuse-google-summer-of-code-2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/01/opensuse-lxde-development-status/index.html
+++ b/2010/03/01/opensuse-lxde-development-status/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/02/index.html
+++ b/2010/03/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/02/openoffice_org-3_2_0_98_1/index.html
+++ b/2010/03/02/openoffice_org-3_2_0_98_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/03/index.html
+++ b/2010/03/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/03/software-opensuse/index.html
+++ b/2010/03/03/software-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/04/index.html
+++ b/2010/03/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/04/time-to-stand-and-be-counted/index.html
+++ b/2010/03/04/time-to-stand-and-be-counted/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/05/additional-packages-that-are-needed-to-get-skype-working-on-opensuse_11-2-x86_64/index.html
+++ b/2010/03/05/additional-packages-that-are-needed-to-get-skype-working-on-opensuse_11-2-x86_64/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/05/index.html
+++ b/2010/03/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/08/index.html
+++ b/2010/03/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/08/new-osc-config-command/index.html
+++ b/2010/03/08/new-osc-config-command/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/09/build-your-own-google-earth-rpm/index.html
+++ b/2010/03/09/build-your-own-google-earth-rpm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/09/index.html
+++ b/2010/03/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/10/flisol-2010-in-nicaragua/index.html
+++ b/2010/03/10/flisol-2010-in-nicaragua/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/10/index.html
+++ b/2010/03/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/10/setting-up-a-slide-show-screen-saver-in-gnome/index.html
+++ b/2010/03/10/setting-up-a-slide-show-screen-saver-in-gnome/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/12/index.html
+++ b/2010/03/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/12/opensuse-on-tv/index.html
+++ b/2010/03/12/opensuse-on-tv/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/13/index.html
+++ b/2010/03/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/13/opensuse-lxde-live-cds/index.html
+++ b/2010/03/13/opensuse-lxde-live-cds/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/15/index.html
+++ b/2010/03/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/15/openoffice_org-3_2_0_99_1/index.html
+++ b/2010/03/15/openoffice_org-3_2_0_99_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/16/index.html
+++ b/2010/03/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/16/opensuse-boosters-update-build-opensuse-org-improvements/index.html
+++ b/2010/03/16/opensuse-boosters-update-build-opensuse-org-improvements/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/17/index.html
+++ b/2010/03/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/17/kraft-0-40-beta-2-available/index.html
+++ b/2010/03/17/kraft-0-40-beta-2-available/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/17/the-kde-plasma-reference/index.html
+++ b/2010/03/17/the-kde-plasma-reference/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/18/flisol-2010-in-venezuela/index.html
+++ b/2010/03/18/flisol-2010-in-venezuela/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/18/index.html
+++ b/2010/03/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/18/opensuse-chemnitzer-linux-tage-2010/index.html
+++ b/2010/03/18/opensuse-chemnitzer-linux-tage-2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/18/panama-awakenings-and-trends/index.html
+++ b/2010/03/18/panama-awakenings-and-trends/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/18/pre-flisol-activities-in-panama/index.html
+++ b/2010/03/18/pre-flisol-activities-in-panama/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/22/fosscomm-2010-in-thessaloniki-greece/index.html
+++ b/2010/03/22/fosscomm-2010-in-thessaloniki-greece/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/22/index.html
+++ b/2010/03/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/22/solving-typical-problems-of-bcm4312-802-11bg/index.html
+++ b/2010/03/22/solving-typical-problems-of-bcm4312-802-11bg/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/23/how-to-add-new-packages-to-the-opensuse-distribution/index.html
+++ b/2010/03/23/how-to-add-new-packages-to-the-opensuse-distribution/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/23/index.html
+++ b/2010/03/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/24/index.html
+++ b/2010/03/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/24/li-f-e-updated-2/index.html
+++ b/2010/03/24/li-f-e-updated-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/29/index.html
+++ b/2010/03/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/29/into-the-cloud/index.html
+++ b/2010/03/29/into-the-cloud/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/29/openoffice_org-3_2_0_99_/index.html
+++ b/2010/03/29/openoffice_org-3_2_0_99_/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/30/index.html
+++ b/2010/03/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/30/russian-opensuse-community/index.html
+++ b/2010/03/30/russian-opensuse-community/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/31/annuncing-kiwi-ltsp-package-updates/index.html
+++ b/2010/03/31/annuncing-kiwi-ltsp-package-updates/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/31/index.html
+++ b/2010/03/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/index.html
+++ b/2010/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/page/2/index.html
+++ b/2010/03/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/03/page/3/index.html
+++ b/2010/03/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/01/announce-opensuse-beego/index.html
+++ b/2010/04/01/announce-opensuse-beego/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/01/index.html
+++ b/2010/04/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/05/index.html
+++ b/2010/04/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/05/news-from-the-zypper-revolution/index.html
+++ b/2010/04/05/news-from-the-zypper-revolution/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/05/small-script-to-monitor-serviceprocess/index.html
+++ b/2010/04/05/small-script-to-monitor-serviceprocess/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/06/index.html
+++ b/2010/04/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/06/installing-ruby-1-9-on-opensuse-11-2/index.html
+++ b/2010/04/06/installing-ruby-1-9-on-opensuse-11-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/07/call-for-testing-unzip-feature/index.html
+++ b/2010/04/07/call-for-testing-unzip-feature/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/07/index.html
+++ b/2010/04/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111502/index.html
+++ b/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111502/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111518/index.html
+++ b/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111518/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111540/index.html
+++ b/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111540/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111600/index.html
+++ b/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111600/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111625/index.html
+++ b/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111625/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111638/index.html
+++ b/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111638/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111738/index.html
+++ b/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111738/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111755/index.html
+++ b/2010/04/13/conference-in-flisol-nicaragua-2010/100405_111755/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/13/conference-in-flisol-nicaragua-2010/index.html
+++ b/2010/04/13/conference-in-flisol-nicaragua-2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/13/index.html
+++ b/2010/04/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/16/index.html
+++ b/2010/04/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/16/osc09-videos/index.html
+++ b/2010/04/16/osc09-videos/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/16/weekly-kernel-review-with-opensuse-flavor-15th-week/index.html
+++ b/2010/04/16/weekly-kernel-review-with-opensuse-flavor-15th-week/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/18/index.html
+++ b/2010/04/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/18/kraft-0-40-for-kde-4-released/index.html
+++ b/2010/04/18/kraft-0-40-for-kde-4-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/19/index.html
+++ b/2010/04/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/19/only-a-few-days-for-the-flisol-in-venezuela/index.html
+++ b/2010/04/19/only-a-few-days-for-the-flisol-in-venezuela/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/20/check-your-wpa2-enterprise-setup/index.html
+++ b/2010/04/20/check-your-wpa2-enterprise-setup/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/20/index.html
+++ b/2010/04/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/20/novell-client-on-opensuse-11-2/index.html
+++ b/2010/04/20/novell-client-on-opensuse-11-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/22/index.html
+++ b/2010/04/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/22/osc-0-126/index.html
+++ b/2010/04/22/osc-0-126/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/23/encrypt-your-files-quick-n-dirty/index.html
+++ b/2010/04/23/encrypt-your-files-quick-n-dirty/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/23/flisol-2010-guayaquil-ecuador-1-day-before/index.html
+++ b/2010/04/23/flisol-2010-guayaquil-ecuador-1-day-before/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/23/guest-blog-kernel-review-with-opensuse-flavor-week-16/index.html
+++ b/2010/04/23/guest-blog-kernel-review-with-opensuse-flavor-week-16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/23/guest-blog-testing-team-minutes-week-16/index.html
+++ b/2010/04/23/guest-blog-testing-team-minutes-week-16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/23/index.html
+++ b/2010/04/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/23/what-people-search-for/index.html
+++ b/2010/04/23/what-people-search-for/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/24/another-outlet-for-opensuse-tv/index.html
+++ b/2010/04/24/another-outlet-for-opensuse-tv/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/24/index.html
+++ b/2010/04/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/24/kde-finance-apps-group-spring-sprint/index.html
+++ b/2010/04/24/kde-finance-apps-group-spring-sprint/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/26/first-round-of-pictures-from-the-flisol-venezuela/index.html
+++ b/2010/04/26/first-round-of-pictures-from-the-flisol-venezuela/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/26/index.html
+++ b/2010/04/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/27/index.html
+++ b/2010/04/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/27/openoffice_org-3_2_0_99_3/index.html
+++ b/2010/04/27/openoffice_org-3_2_0_99_3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/27/trophy-from-ibm-develothon-2010/index.html
+++ b/2010/04/27/trophy-from-ibm-develothon-2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/29/index.html
+++ b/2010/04/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/29/making-of-the-opensuse-install-video/index.html
+++ b/2010/04/29/making-of-the-opensuse-install-video/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/index.html
+++ b/2010/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/page/2/index.html
+++ b/2010/04/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/04/page/3/index.html
+++ b/2010/04/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/01/guest-blog-weekly-minutes-from-the-testing-team-larry-finger/index.html
+++ b/2010/05/01/guest-blog-weekly-minutes-from-the-testing-team-larry-finger/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/01/index.html
+++ b/2010/05/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/dsc07904/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/dsc07904/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/dsc07908/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/dsc07908/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/dsc08864/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/dsc08864/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/dsc08871/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/dsc08871/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/dsc08872/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/dsc08872/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/dsc08873/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/dsc08873/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/dsc08874/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/dsc08874/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/dsc08875/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/dsc08875/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/dsc08876/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/dsc08876/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/dsc08878/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/dsc08878/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/dsc08880/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/dsc08880/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/dsc08884/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/dsc08884/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/flisol-nicaragua-2010/index.html
+++ b/2010/05/02/flisol-nicaragua-2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/02/index.html
+++ b/2010/05/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/03/a-lizard/index.html
+++ b/2010/05/03/a-lizard/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/03/index.html
+++ b/2010/05/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/03/preparation-for-mounting-varrun-as-tmpfs/index.html
+++ b/2010/05/03/preparation-for-mounting-varrun-as-tmpfs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/03/second-round-of-pictures-from-the-flisol-venezuela/index.html
+++ b/2010/05/03/second-round-of-pictures-from-the-flisol-venezuela/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/06/a-blog-on-sourceforge/index.html
+++ b/2010/05/06/a-blog-on-sourceforge/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/06/index.html
+++ b/2010/05/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/07/flisol-2010-in-panama-city/index.html
+++ b/2010/05/07/flisol-2010-in-panama-city/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/07/index.html
+++ b/2010/05/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/07/opensuse-at-universidad-de-panama-fiec/index.html
+++ b/2010/05/07/opensuse-at-universidad-de-panama-fiec/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/07/promoting-open-source-communities-in-panama/index.html
+++ b/2010/05/07/promoting-open-source-communities-in-panama/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/08/guest-blog-rares-aioanai-gives-a-kernel-review-week-18/index.html
+++ b/2010/05/08/guest-blog-rares-aioanai-gives-a-kernel-review-week-18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/08/index.html
+++ b/2010/05/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/12/9-15052010-a-week-that-will-be-a-milestone-on-gnulinux-gaming/index.html
+++ b/2010/05/12/9-15052010-a-week-that-will-be-a-milestone-on-gnulinux-gaming/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/12/index.html
+++ b/2010/05/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/13/index.html
+++ b/2010/05/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/13/your-own-oem-configuration-yast-firstboot/index.html
+++ b/2010/05/13/your-own-oem-configuration-yast-firstboot/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/14/guest-blog-rares-aioanei-kernel-news-with-opensuse-flavor/index.html
+++ b/2010/05/14/guest-blog-rares-aioanei-kernel-news-with-opensuse-flavor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/14/index.html
+++ b/2010/05/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/14/opensuse-lxde-and-italian-press/index.html
+++ b/2010/05/14/opensuse-lxde-and-italian-press/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/15/index.html
+++ b/2010/05/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/15/lugaru-is-opensource-lugaru-is-on-packman/index.html
+++ b/2010/05/15/lugaru-is-opensource-lugaru-is-on-packman/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/16/index.html
+++ b/2010/05/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/16/opensuse-gnome-team-meeting/index.html
+++ b/2010/05/16/opensuse-gnome-team-meeting/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/17/index.html
+++ b/2010/05/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/17/openoffice_org-3_2_1_1/index.html
+++ b/2010/05/17/openoffice_org-3_2_1_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/20/apache2-icons-oxygen-is-now-in-factory/index.html
+++ b/2010/05/20/apache2-icons-oxygen-is-now-in-factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/20/index.html
+++ b/2010/05/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/21/guest-blog-rares-aioanei-kernel-review-with-opensuse-flavor/index.html
+++ b/2010/05/21/guest-blog-rares-aioanei-kernel-review-with-opensuse-flavor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/21/index.html
+++ b/2010/05/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/25/automated-opensuse-testing/index.html
+++ b/2010/05/25/automated-opensuse-testing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Testing is an important task. But testing daily openSUSE-Factory snapshots would mean testing the same things every day. This would be pretty tiresome to people." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/25/index.html
+++ b/2010/05/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/25/opensuse-schools-in-nicaragua/index.html
+++ b/2010/05/25/opensuse-schools-in-nicaragua/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/25/red-hot-geeko/index.html
+++ b/2010/05/25/red-hot-geeko/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/27/index.html
+++ b/2010/05/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/27/openoffice_org-3_2_1_2/index.html
+++ b/2010/05/27/openoffice_org-3_2_1_2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/28/how-to-set-up-a-production-server-for-your-rails-app/index.html
+++ b/2010/05/28/how-to-set-up-a-production-server-for-your-rails-app/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/28/index.html
+++ b/2010/05/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/28/kde-sc-4-5-beta-1-available-for-opensuse/index.html
+++ b/2010/05/28/kde-sc-4-5-beta-1-available-for-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/28/novell-hackweek-fife/index.html
+++ b/2010/05/28/novell-hackweek-fife/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/28/opensuse-at-flisol-chile/index.html
+++ b/2010/05/28/opensuse-at-flisol-chile/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/29/guest-blog-rares-aioanei-weekly-kernel-review/index.html
+++ b/2010/05/29/guest-blog-rares-aioanei-weekly-kernel-review/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/29/guest-blog-rares-aioanei-weekly-review-of-postgresql/index.html
+++ b/2010/05/29/guest-blog-rares-aioanei-weekly-review-of-postgresql/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/29/index.html
+++ b/2010/05/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/index.html
+++ b/2010/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/page/2/index.html
+++ b/2010/05/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/05/page/3/index.html
+++ b/2010/05/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/01/index.html
+++ b/2010/06/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/01/openoffice_org-3_2_1_3/index.html
+++ b/2010/06/01/openoffice_org-3_2_1_3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/03/acetoneiso2-and-lxde/index.html
+++ b/2010/06/03/acetoneiso2-and-lxde/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/03/flisol-2010-gye-some-late-numbers-and-experiences/index.html
+++ b/2010/06/03/flisol-2010-gye-some-late-numbers-and-experiences/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/03/index.html
+++ b/2010/06/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/04/guest-blog-rares-aioanei-weekly-kernel-review-with-opensuse-flavor/index.html
+++ b/2010/06/04/guest-blog-rares-aioanei-weekly-kernel-review-with-opensuse-flavor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/04/guest-blog-rares-aioanei-weekly-review-of-the-postgresql-project-with-opensuse-flavor/index.html
+++ b/2010/06/04/guest-blog-rares-aioanei-weekly-review-of-the-postgresql-project-with-opensuse-flavor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/04/index.html
+++ b/2010/06/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/04/opengarrobito-0-4-5/index.html
+++ b/2010/06/04/opengarrobito-0-4-5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/04/qt-developer-days-2010/index.html
+++ b/2010/06/04/qt-developer-days-2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/07/hacking-for-freedom/index.html
+++ b/2010/06/07/hacking-for-freedom/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/07/index.html
+++ b/2010/06/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/08/hackweek5/index.html
+++ b/2010/06/08/hackweek5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/08/index.html
+++ b/2010/06/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/09/happy-15th-php/index.html
+++ b/2010/06/09/happy-15th-php/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/09/index.html
+++ b/2010/06/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/10/index.html
+++ b/2010/06/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/10/road-to-11-3-when-pattern-are-not-your-friend-pre-selection-can-be-a-trap/index.html
+++ b/2010/06/10/road-to-11-3-when-pattern-are-not-your-friend-pre-selection-can-be-a-trap/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/11/guest-blog-rares-aioanei-weekly-kernel-review-opensuse-flavor/index.html
+++ b/2010/06/11/guest-blog-rares-aioanei-weekly-kernel-review-opensuse-flavor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/11/guest-blog-rares-aioanei-weekly-review-from-postgresql-opensuse-flavor/index.html
+++ b/2010/06/11/guest-blog-rares-aioanei-weekly-review-from-postgresql-opensuse-flavor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/11/index.html
+++ b/2010/06/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/11/zippl-a-lightweigth-presentation-tool/index.html
+++ b/2010/06/11/zippl-a-lightweigth-presentation-tool/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/12/improve-software-quality/index.html
+++ b/2010/06/12/improve-software-quality/index.html
@@ -22,15 +22,10 @@
 Ubuntu is still ahead of openSUSE in some regards of quality. There are things we can learn from them..." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/12/index.html
+++ b/2010/06/12/index.html
@@ -22,15 +22,10 @@
 Ubuntu is still ahead of openSUSE in some regards of quality. There are things we can learn from them..." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/12/linuxtag-2010-in-berlin/index.html
+++ b/2010/06/12/linuxtag-2010-in-berlin/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/13/index.html
+++ b/2010/06/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/13/some-linuxtag-2010-impressions/index.html
+++ b/2010/06/13/some-linuxtag-2010-impressions/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/14/hackweek-v-local-caching-for-cifs-network-file-system/index.html
+++ b/2010/06/14/hackweek-v-local-caching-for-cifs-network-file-system/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/14/hello-word/index.html
+++ b/2010/06/14/hello-word/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/14/index.html
+++ b/2010/06/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/14/opensuse-edu-li-f-e-theme-for-11-3/index.html
+++ b/2010/06/14/opensuse-edu-li-f-e-theme-for-11-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/14/some-wrap-up-from-linuxtag/index.html
+++ b/2010/06/14/some-wrap-up-from-linuxtag/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/15/hackweek-v-osc-bash-completion/index.html
+++ b/2010/06/15/hackweek-v-osc-bash-completion/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/15/index.html
+++ b/2010/06/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/16/hackweek-v-mkdiststats/index.html
+++ b/2010/06/16/hackweek-v-mkdiststats/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/16/index.html
+++ b/2010/06/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/18/guest-blog-rares-aaioanei-weekly-review-of-postgresql-project-with-opensuse-flavor/index.html
+++ b/2010/06/18/guest-blog-rares-aaioanei-weekly-review-of-postgresql-project-with-opensuse-flavor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/18/guest-blog-rares-aioanei-weekly-kernel-review-opensuse-flavor-2/index.html
+++ b/2010/06/18/guest-blog-rares-aioanei-weekly-kernel-review-opensuse-flavor-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/18/index.html
+++ b/2010/06/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/18/openoffice_org-3_2_1_4-bugfix/index.html
+++ b/2010/06/18/openoffice_org-3_2_1_4-bugfix/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/21/augmented-reality-in-opensuse-11-2/index.html
+++ b/2010/06/21/augmented-reality-in-opensuse-11-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/21/index.html
+++ b/2010/06/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/22/call-for-voters/index.html
+++ b/2010/06/22/call-for-voters/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/22/index.html
+++ b/2010/06/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/23/index.html
+++ b/2010/06/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/23/lets-beat-the-drum-for-opensuse-conference-2010/index.html
+++ b/2010/06/23/lets-beat-the-drum-for-opensuse-conference-2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/26/buildservice-development-on-11-3/index.html
+++ b/2010/06/26/buildservice-development-on-11-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/26/guest-blog-rares-aioanei-postgresql-review-opensuse-flavor/index.html
+++ b/2010/06/26/guest-blog-rares-aioanei-postgresql-review-opensuse-flavor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/26/guest-blog-rares-aioanei-weekly-kernel-review-opensuse-flavor-3/index.html
+++ b/2010/06/26/guest-blog-rares-aioanei-weekly-kernel-review-opensuse-flavor-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/26/index.html
+++ b/2010/06/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/index.html
+++ b/2010/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/page/2/index.html
+++ b/2010/06/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/page/3/index.html
+++ b/2010/06/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/06/page/4/index.html
+++ b/2010/06/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/03/guest-blog-rares-aioanei-kernel-weekly-review-with-opensuse-flavor/index.html
+++ b/2010/07/03/guest-blog-rares-aioanei-kernel-weekly-review-with-opensuse-flavor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/03/guest-blog-rares-aioanei-weekly-review-of-postgresql-with-opensuse-flavor/index.html
+++ b/2010/07/03/guest-blog-rares-aioanei-weekly-review-of-postgresql-with-opensuse-flavor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/03/index.html
+++ b/2010/07/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/05/article-about-ipad-with-linux-brasilian-portuguese/index.html
+++ b/2010/07/05/article-about-ipad-with-linux-brasilian-portuguese/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/05/index.html
+++ b/2010/07/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/05/opensuse-11-2-and-obs-at-universidad-latina/index.html
+++ b/2010/07/05/opensuse-11-2-and-obs-at-universidad-latina/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/07/index.html
+++ b/2010/07/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/07/opensuse-edu-li-f-e-11-3-rc1/index.html
+++ b/2010/07/07/opensuse-edu-li-f-e-11-3-rc1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/09/index.html
+++ b/2010/07/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/09/shortcut-for-the-package-download/index.html
+++ b/2010/07/09/shortcut-for-the-package-download/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/12/index.html
+++ b/2010/07/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/12/opensuse-conference-2010/index.html
+++ b/2010/07/12/opensuse-conference-2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/13/index.html
+++ b/2010/07/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/13/workshop-at-party-quijote/dsc_0002/index.html
+++ b/2010/07/13/workshop-at-party-quijote/dsc_0002/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/13/workshop-at-party-quijote/dsc_0009/index.html
+++ b/2010/07/13/workshop-at-party-quijote/dsc_0009/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/13/workshop-at-party-quijote/dsc_0010/index.html
+++ b/2010/07/13/workshop-at-party-quijote/dsc_0010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/13/workshop-at-party-quijote/dsc_0017/index.html
+++ b/2010/07/13/workshop-at-party-quijote/dsc_0017/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/13/workshop-at-party-quijote/dsc_0025/index.html
+++ b/2010/07/13/workshop-at-party-quijote/dsc_0025/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/13/workshop-at-party-quijote/dsc_0041/index.html
+++ b/2010/07/13/workshop-at-party-quijote/dsc_0041/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/13/workshop-at-party-quijote/index.html
+++ b/2010/07/13/workshop-at-party-quijote/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/14/index.html
+++ b/2010/07/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/14/obs-development-team-member-job-position/index.html
+++ b/2010/07/14/obs-development-team-member-job-position/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/15/index.html
+++ b/2010/07/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/16/index.html
+++ b/2010/07/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/16/opensuse-11-3-launch-party-in-nurnberg/index.html
+++ b/2010/07/16/opensuse-11-3-launch-party-in-nurnberg/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/17/index.html
+++ b/2010/07/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/17/opensuse-edu-li-f-e-11-3-available-now/index.html
+++ b/2010/07/17/opensuse-edu-li-f-e-11-3-available-now/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/18/index.html
+++ b/2010/07/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/18/opensuse-launch-party-at-msu-bca-vadodara/index.html
+++ b/2010/07/18/opensuse-launch-party-at-msu-bca-vadodara/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/19/git-bisect-in-action/index.html
+++ b/2010/07/19/git-bisect-in-action/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/19/index.html
+++ b/2010/07/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/19/opensuse-present-in-the-especial-edition-of-cibess/index.html
+++ b/2010/07/19/opensuse-present-in-the-especial-edition-of-cibess/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/22/how-to-setup-edu-servers-on-li-f-e/index.html
+++ b/2010/07/22/how-to-setup-edu-servers-on-li-f-e/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/22/index.html
+++ b/2010/07/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/23/index.html
+++ b/2010/07/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/23/opensuse-lxde-11-3-live-cd/index.html
+++ b/2010/07/23/opensuse-lxde-11-3-live-cd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/23/universal-go-oo-3_2_1/index.html
+++ b/2010/07/23/universal-go-oo-3_2_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/25/how-to-change-gdm-backgroundwallpaper/index.html
+++ b/2010/07/25/how-to-change-gdm-backgroundwallpaper/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/25/index.html
+++ b/2010/07/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/25/opensuse-lxde-11-3-rc1-live-cd-available-for-download/index.html
+++ b/2010/07/25/opensuse-lxde-11-3-rc1-live-cd-available-for-download/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/index.html
+++ b/2010/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/07/page/2/index.html
+++ b/2010/07/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/01/index.html
+++ b/2010/08/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/01/somethings-to-do-after-an-opensuse-installation/index.html
+++ b/2010/08/01/somethings-to-do-after-an-opensuse-installation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/04/index.html
+++ b/2010/08/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/04/software-search-trick/index.html
+++ b/2010/08/04/software-search-trick/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/05/bugs-will-not-get-fixed-by-themselves/index.html
+++ b/2010/08/05/bugs-will-not-get-fixed-by-themselves/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/05/index.html
+++ b/2010/08/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/05/local-caching-for-cifs-network-file-system-followup/index.html
+++ b/2010/08/05/local-caching-for-cifs-network-file-system-followup/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/06/index.html
+++ b/2010/08/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/06/status-openfate-milestone/index.html
+++ b/2010/08/06/status-openfate-milestone/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/08/index.html
+++ b/2010/08/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/08/latex-editors-and-rubber/index.html
+++ b/2010/08/08/latex-editors-and-rubber/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="I have started maintaining three packages, namely Texmaker, TeXworks and Rubber, in the Publishing repository. These applications make working with and compiling latex documents user friendly and painless." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/08/opensuse-launchparty-in-merida-venezuela/index.html
+++ b/2010/08/08/opensuse-launchparty-in-merida-venezuela/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/09/index.html
+++ b/2010/08/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/09/somethings-to-do-after-an-opensuse-installation-part-2/index.html
+++ b/2010/08/09/somethings-to-do-after-an-opensuse-installation-part-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/11/index.html
+++ b/2010/08/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/11/problems-installing-software-in-opensuse-simple-solution/index.html
+++ b/2010/08/11/problems-installing-software-in-opensuse-simple-solution/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/12/index.html
+++ b/2010/08/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/12/osc10-conference-update/index.html
+++ b/2010/08/12/osc10-conference-update/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/15/index.html
+++ b/2010/08/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/15/kde-release-party-in-madrid/index.html
+++ b/2010/08/15/kde-release-party-in-madrid/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/15/obs-2-1-features-and-status/index.html
+++ b/2010/08/15/obs-2-1-features-and-status/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/20/im-going-to-froscon/index.html
+++ b/2010/08/20/im-going-to-froscon/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/20/index.html
+++ b/2010/08/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/21/index.html
+++ b/2010/08/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/21/opensuse-boosters-at-froscon-day-1/index.html
+++ b/2010/08/21/opensuse-boosters-at-froscon-day-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/22/index.html
+++ b/2010/08/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/22/obs-2-1-status-of-powerpc-and-mips-support-with-qemu/index.html
+++ b/2010/08/22/obs-2-1-status-of-powerpc-and-mips-support-with-qemu/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/22/opensuse-boosters-at-froscon-day-2/index.html
+++ b/2010/08/22/opensuse-boosters-at-froscon-day-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/25/index.html
+++ b/2010/08/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/25/my-wallpaper-and-banner-with-gecko-jedi/index.html
+++ b/2010/08/25/my-wallpaper-and-banner-with-gecko-jedi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/25/posture-of-a-jedi/index.html
+++ b/2010/08/25/posture-of-a-jedi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/25/revising-the-board-election-rules/index.html
+++ b/2010/08/25/revising-the-board-election-rules/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/30/come-on-join-the-bacula-developer-conference/index.html
+++ b/2010/08/30/come-on-join-the-bacula-developer-conference/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/30/index.html
+++ b/2010/08/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/30/whats-cooking-in-opensuses-gnome-for-11-4/index.html
+++ b/2010/08/30/whats-cooking-in-opensuses-gnome-for-11-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/index.html
+++ b/2010/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/page/2/index.html
+++ b/2010/08/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/08/page/3/index.html
+++ b/2010/08/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/04/index.html
+++ b/2010/09/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/04/recompiling-wxruby/index.html
+++ b/2010/09/04/recompiling-wxruby/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/08/index.html
+++ b/2010/09/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/08/kiwi-ltsp-multiple-image-support-improvements/index.html
+++ b/2010/09/08/kiwi-ltsp-multiple-image-support-improvements/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/12/index.html
+++ b/2010/09/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/12/kde-bug-triage-report/index.html
+++ b/2010/09/12/kde-bug-triage-report/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/13/build-service-cheat-sheet/index.html
+++ b/2010/09/13/build-service-cheat-sheet/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/13/index.html
+++ b/2010/09/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/14/another-opensuse-kernel-git-repo/index.html
+++ b/2010/09/14/another-opensuse-kernel-git-repo/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/14/index.html
+++ b/2010/09/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/14/on-access-virus-scanning-on-opensuse-11-3/index.html
+++ b/2010/09/14/on-access-virus-scanning-on-opensuse-11-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/14/systems-management-zeitgeist/index.html
+++ b/2010/09/14/systems-management-zeitgeist/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/17/free-beer-for-free-people/index.html
+++ b/2010/09/17/free-beer-for-free-people/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/17/froscamp-day-i/index.html
+++ b/2010/09/17/froscamp-day-i/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/17/index.html
+++ b/2010/09/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/19/froscamp-2010-zurich-the-day-after-event-report/index.html
+++ b/2010/09/19/froscamp-2010-zurich-the-day-after-event-report/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/19/froscamp-day-ii/index.html
+++ b/2010/09/19/froscamp-day-ii/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/19/index.html
+++ b/2010/09/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/22/index.html
+++ b/2010/09/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/22/qt-4-7-0-in-opensuse-kde-updates/index.html
+++ b/2010/09/22/qt-4-7-0-in-opensuse-kde-updates/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/23/index.html
+++ b/2010/09/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/23/wacom-bamboo-pen-and-opensuse-11-3/index.html
+++ b/2010/09/23/wacom-bamboo-pen-and-opensuse-11-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/24/from-source-code-to-packages-for-various-distributions/index.html
+++ b/2010/09/24/from-source-code-to-packages-for-various-distributions/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/24/index.html
+++ b/2010/09/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/29/index.html
+++ b/2010/09/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/29/revising-the-board-election-rules-2nd-iteration/index.html
+++ b/2010/09/29/revising-the-board-election-rules-2nd-iteration/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/30/index.html
+++ b/2010/09/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/30/opensuse-kde-meeting-tonight-last-minute-qt-dev-days-giveaway/index.html
+++ b/2010/09/30/opensuse-kde-meeting-tonight-last-minute-qt-dev-days-giveaway/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/index.html
+++ b/2010/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/09/page/2/index.html
+++ b/2010/09/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/01/index.html
+++ b/2010/10/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/01/new-design-of-lizards-and-avatars/index.html
+++ b/2010/10/01/new-design-of-lizards-and-avatars/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/03/checking-epubs/index.html
+++ b/2010/10/03/checking-epubs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/03/index.html
+++ b/2010/10/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/07/index.html
+++ b/2010/10/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/07/pcmanfm-now-add-the-support-to-move-able-icons-on-the-desktop/index.html
+++ b/2010/10/07/pcmanfm-now-add-the-support-to-move-able-icons-on-the-desktop/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/08/adventures-with-intel-atom-d510-board/index.html
+++ b/2010/10/08/adventures-with-intel-atom-d510-board/index.html
@@ -22,15 +22,10 @@
 I have 2 Intel Atom's running for my mail and web servers and I was quite happy with their performances, (by the way I am still happy). Hence I decided to ride the change train and bought the Intel D510 board" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/08/index.html
+++ b/2010/10/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/08/its-good-to-visit-conferences/index.html
+++ b/2010/10/08/its-good-to-visit-conferences/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/08/revising-the-board-election-rules-3rd-iteration/index.html
+++ b/2010/10/08/revising-the-board-election-rules-3rd-iteration/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/08/systemd-and-osc2010/index.html
+++ b/2010/10/08/systemd-and-osc2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/13/documentation/index.html
+++ b/2010/10/13/documentation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/13/index.html
+++ b/2010/10/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/15/index.html
+++ b/2010/10/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/15/libreoffice-3_2_99_2/index.html
+++ b/2010/10/15/libreoffice-3_2_99_2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/15/opensuse-conference-kde-team-party/index.html
+++ b/2010/10/15/opensuse-conference-kde-team-party/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/17/3dmedwinz-picasaweb-hrefhttppicasaweb-google-commedwinzicteqep-target_blankpicasaweb/index.html
+++ b/2010/10/17/3dmedwinz-picasaweb-hrefhttppicasaweb-google-commedwinzicteqep-target_blankpicasaweb/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/17/index.html
+++ b/2010/10/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/20/index.html
+++ b/2010/10/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="A matryoshka doll, also known as a Russian nesting doll or a babushka doll, is a set of dolls of decreasing sizes placed one inside the other. Virtualization is a concept similar to the Matryoshka analogy. There is another system running inside the host machine. So it is box in a box. Each performs and executes exactly like a stand-alone server; a container can be rebooted independently and have root access, users, IP addresses, memory, processes, files, applications, system libraries and configuration files." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/20/matryoshka/index.html
+++ b/2010/10/20/matryoshka/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="A matryoshka doll, also known as a Russian nesting doll or a babushka doll, is a set of dolls of decreasing sizes placed one inside the other. Virtualization is a concept similar to the Matryoshka analogy. There is another system running inside the host machine. So it is box in a box. Each performs and executes exactly like a stand-alone server; a container can be rebooted independently and have root access, users, IP addresses, memory, processes, files, applications, system libraries and configuration files." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/21/fotostream-from-opensuse-conference-2010/index.html
+++ b/2010/10/21/fotostream-from-opensuse-conference-2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/21/index.html
+++ b/2010/10/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/23/index.html
+++ b/2010/10/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/23/opensuse-conference/index.html
+++ b/2010/10/23/opensuse-conference/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/23/rtfm/index.html
+++ b/2010/10/23/rtfm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/24/index.html
+++ b/2010/10/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/24/obs-2-1-status-of-superh-sh4-support-with-qemu/index.html
+++ b/2010/10/24/obs-2-1-status-of-superh-sh4-support-with-qemu/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/24/upstream-holiday/index.html
+++ b/2010/10/24/upstream-holiday/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/26/cheat-cube-opensuse/index.html
+++ b/2010/10/26/cheat-cube-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/26/index.html
+++ b/2010/10/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/26/read-the-fabulous-manual/index.html
+++ b/2010/10/26/read-the-fabulous-manual/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/28/a-new-flavor-opensuse-invis-server/index.html
+++ b/2010/10/28/a-new-flavor-opensuse-invis-server/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/28/index.html
+++ b/2010/10/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/30/index.html
+++ b/2010/10/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/30/merging-svn-repos-explained/index.html
+++ b/2010/10/30/merging-svn-repos-explained/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/index.html
+++ b/2010/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/page/2/index.html
+++ b/2010/10/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/10/page/3/index.html
+++ b/2010/10/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/07/index.html
+++ b/2010/11/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/07/limobile-linux-sdk-for-mobiles-apple/index.html
+++ b/2010/11/07/limobile-linux-sdk-for-mobiles-apple/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/08/index.html
+++ b/2010/11/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/08/openfate-screening-meeting/index.html
+++ b/2010/11/08/openfate-screening-meeting/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/09/10-obscure-linux-office-applications/index.html
+++ b/2010/11/09/10-obscure-linux-office-applications/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/09/index.html
+++ b/2010/11/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/09/me-is-leaving/index.html
+++ b/2010/11/09/me-is-leaving/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/attachment/09102010185/index.html
+++ b/2010/11/10/busy-oktober/attachment/09102010185/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/attachment/11102010190/index.html
+++ b/2010/11/10/busy-oktober/attachment/11102010190/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/attachment/12102010198/index.html
+++ b/2010/11/10/busy-oktober/attachment/12102010198/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/attachment/20102010203/index.html
+++ b/2010/11/10/busy-oktober/attachment/20102010203/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0010-2/index.html
+++ b/2010/11/10/busy-oktober/dsc_0010-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0015/index.html
+++ b/2010/11/10/busy-oktober/dsc_0015/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0029/index.html
+++ b/2010/11/10/busy-oktober/dsc_0029/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0030/index.html
+++ b/2010/11/10/busy-oktober/dsc_0030/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0047/index.html
+++ b/2010/11/10/busy-oktober/dsc_0047/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0052/index.html
+++ b/2010/11/10/busy-oktober/dsc_0052/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0053/index.html
+++ b/2010/11/10/busy-oktober/dsc_0053/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0067/index.html
+++ b/2010/11/10/busy-oktober/dsc_0067/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0069/index.html
+++ b/2010/11/10/busy-oktober/dsc_0069/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0073/index.html
+++ b/2010/11/10/busy-oktober/dsc_0073/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0104/index.html
+++ b/2010/11/10/busy-oktober/dsc_0104/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0143/index.html
+++ b/2010/11/10/busy-oktober/dsc_0143/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/dsc_0179/index.html
+++ b/2010/11/10/busy-oktober/dsc_0179/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/busy-oktober/index.html
+++ b/2010/11/10/busy-oktober/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/10/index.html
+++ b/2010/11/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/11/index.html
+++ b/2010/11/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/11/opensuse-medical-team-releases-stable-version-0-0-6/index.html
+++ b/2010/11/11/opensuse-medical-team-releases-stable-version-0-0-6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/12/handling-of-features-in-openfate/index.html
+++ b/2010/11/12/handling-of-features-in-openfate/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/12/index.html
+++ b/2010/11/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/12/opensuse-11-3sles-11-integrating-freeradius-to-ldap-server/index.html
+++ b/2010/11/12/opensuse-11-3sles-11-integrating-freeradius-to-ldap-server/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/15/index.html
+++ b/2010/11/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/15/make-vmware-workstation-7-1-3-running-with-11-4-kernel-2-6-37/index.html
+++ b/2010/11/15/make-vmware-workstation-7-1-3-running-with-11-4-kernel-2-6-37/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/16/index.html
+++ b/2010/11/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/16/new-package-for-packager-whohas/index.html
+++ b/2010/11/16/new-package-for-packager-whohas/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/16/webyast-now-for-opensuse/index.html
+++ b/2010/11/16/webyast-now-for-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/17/index.html
+++ b/2010/11/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/17/status-hu-opensuse-documentation/index.html
+++ b/2010/11/17/status-hu-opensuse-documentation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/20/index.html
+++ b/2010/11/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/20/just-a-small-story-about-my-ambassador-life/index.html
+++ b/2010/11/20/just-a-small-story-about-my-ambassador-life/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/22/bugday/index.html
+++ b/2010/11/22/bugday/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/22/index.html
+++ b/2010/11/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/22/libreoffice-3_2_99_3/index.html
+++ b/2010/11/22/libreoffice-3_2_99_3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/22/please-note/index.html
+++ b/2010/11/22/please-note/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/24/index.html
+++ b/2010/11/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/24/updated-permissions-handling-in-11-4/index.html
+++ b/2010/11/24/updated-permissions-handling-in-11-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/29/announcing-factory-tested/index.html
+++ b/2010/11/29/announcing-factory-tested/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="There is something new that is better than Factory and Milestones in some regards: factory-tested which has a known minimum quality and frequent releases." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/29/index.html
+++ b/2010/11/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="There is something new that is better than Factory and Milestones in some regards: factory-tested which has a known minimum quality and frequent releases." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/index.html
+++ b/2010/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="There is something new that is better than Factory and Milestones in some regards: factory-tested which has a known minimum quality and frequent releases." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/11/page/2/index.html
+++ b/2010/11/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/01/googleearth-6-0-running-in-opensuse-11-4-factory-64bits/index.html
+++ b/2010/12/01/googleearth-6-0-running-in-opensuse-11-4-factory-64bits/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/01/hermes-work/index.html
+++ b/2010/12/01/hermes-work/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/01/index.html
+++ b/2010/12/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/02/christmas-dinner-11th-december-aveiro-portugal/index.html
+++ b/2010/12/02/christmas-dinner-11th-december-aveiro-portugal/index.html
@@ -23,15 +23,10 @@
 The event will take place in the city of Aveiro (Silver Coast, Portugal). The Dinner will be at 21:00 in the Pizzarte (an Italian Restaurant, which also has vegetarian service). The meet place is also Pizzarte at 20:30. There are no reservations required and the event will be on a non-smokers area." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/02/index.html
+++ b/2010/12/02/index.html
@@ -23,15 +23,10 @@
 The event will take place in the city of Aveiro (Silver Coast, Portugal). The Dinner will be at 21:00 in the Pizzarte (an Italian Restaurant, which also has vegetarian service). The meet place is also Pizzarte at 20:30. There are no reservations required and the event will be on a non-smokers area." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/03/index.html
+++ b/2010/12/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/03/libreoffice-3_3_0_/index.html
+++ b/2010/12/03/libreoffice-3_3_0_/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/05/index.html
+++ b/2010/12/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/05/unity-maybe-on-fedora/index.html
+++ b/2010/12/05/unity-maybe-on-fedora/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/06/a-new-aeon-a-new-team-of-ambassadors/index.html
+++ b/2010/12/06/a-new-aeon-a-new-team-of-ambassadors/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/06/index.html
+++ b/2010/12/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/06/osc-0-130/index.html
+++ b/2010/12/06/osc-0-130/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/07/index.html
+++ b/2010/12/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/07/indicator-me-has-landed/index.html
+++ b/2010/12/07/indicator-me-has-landed/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/09/happy-birthday-scribus/index.html
+++ b/2010/12/09/happy-birthday-scribus/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/09/index.html
+++ b/2010/12/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/09/indicator-sessionnetwork/index.html
+++ b/2010/12/09/indicator-sessionnetwork/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/10/index.html
+++ b/2010/12/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/10/new-indicators-the-saga-continues/index.html
+++ b/2010/12/10/new-indicators-the-saga-continues/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/11/index.html
+++ b/2010/12/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/11/new-day-new-indicator/index.html
+++ b/2010/12/11/new-day-new-indicator/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/12/index.html
+++ b/2010/12/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/12/outcome-of-the-christmas-dinner/index.html
+++ b/2010/12/12/outcome-of-the-christmas-dinner/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/13/index.html
+++ b/2010/12/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/13/last-indicator-builds/index.html
+++ b/2010/12/13/last-indicator-builds/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/14/board-elections/index.html
+++ b/2010/12/14/board-elections/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/14/index.html
+++ b/2010/12/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/15/index.html
+++ b/2010/12/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/15/verein-computerspende-hamburg-and-opensuse/index.html
+++ b/2010/12/15/verein-computerspende-hamburg-and-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/16/10-minutes-of-your-time/index.html
+++ b/2010/12/16/10-minutes-of-your-time/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/16/how-we-use-our-power/index.html
+++ b/2010/12/16/how-we-use-our-power/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/16/index.html
+++ b/2010/12/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/17/adobe-flash-64-bits-under-opensuse-64bits-11-211-311-4factory/index.html
+++ b/2010/12/17/adobe-flash-64-bits-under-opensuse-64bits-11-211-311-4factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/17/index.html
+++ b/2010/12/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/17/unity-on-opensuse-maybe/index.html
+++ b/2010/12/17/unity-on-opensuse-maybe/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/18/index.html
+++ b/2010/12/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/18/osc-0-130-1-bugfix-release/index.html
+++ b/2010/12/18/osc-0-130-1-bugfix-release/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/20/happy-winter-solstice/index.html
+++ b/2010/12/20/happy-winter-solstice/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/20/index.html
+++ b/2010/12/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/21/easy-use-of-webyast-for-opensuse-11-3/index.html
+++ b/2010/12/21/easy-use-of-webyast-for-opensuse-11-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/21/index.html
+++ b/2010/12/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/23/index.html
+++ b/2010/12/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/23/more-unity-news/index.html
+++ b/2010/12/23/more-unity-news/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/23/rubygem-studio_api/index.html
+++ b/2010/12/23/rubygem-studio_api/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/29/index.html
+++ b/2010/12/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/29/kick-off-for-gnomeayatana-project/index.html
+++ b/2010/12/29/kick-off-for-gnomeayatana-project/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/index.html
+++ b/2010/12/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/kokoa-and-friends-meeting-kya2010/group/index.html
+++ b/2010/12/31/kokoa-and-friends-meeting-kya2010/group/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/kokoa-and-friends-meeting-kya2010/hector/index.html
+++ b/2010/12/31/kokoa-and-friends-meeting-kya2010/hector/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/kokoa-and-friends-meeting-kya2010/img_1122/index.html
+++ b/2010/12/31/kokoa-and-friends-meeting-kya2010/img_1122/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/kokoa-and-friends-meeting-kya2010/img_1128/index.html
+++ b/2010/12/31/kokoa-and-friends-meeting-kya2010/img_1128/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/kokoa-and-friends-meeting-kya2010/img_1160/index.html
+++ b/2010/12/31/kokoa-and-friends-meeting-kya2010/img_1160/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/kokoa-and-friends-meeting-kya2010/index.html
+++ b/2010/12/31/kokoa-and-friends-meeting-kya2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/kokoa-and-friends-meeting-kya2010/jarflex/index.html
+++ b/2010/12/31/kokoa-and-friends-meeting-kya2010/jarflex/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/kokoa-and-friends-meeting-kya2010/marisol/index.html
+++ b/2010/12/31/kokoa-and-friends-meeting-kya2010/marisol/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/kokoa-and-friends-meeting-kya2010/nervo/index.html
+++ b/2010/12/31/kokoa-and-friends-meeting-kya2010/nervo/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/kokoa-and-friends-meeting-kya2010/preparing/index.html
+++ b/2010/12/31/kokoa-and-friends-meeting-kya2010/preparing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/kokoa-and-friends-meeting-kya2010/preparing2/index.html
+++ b/2010/12/31/kokoa-and-friends-meeting-kya2010/preparing2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/31/kokoa-and-friends-meeting-kya2010/tini/index.html
+++ b/2010/12/31/kokoa-and-friends-meeting-kya2010/tini/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/index.html
+++ b/2010/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/page/2/index.html
+++ b/2010/12/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/12/page/3/index.html
+++ b/2010/12/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/index.html
+++ b/2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/10/index.html
+++ b/2010/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/11/index.html
+++ b/2010/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/12/index.html
+++ b/2010/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/13/index.html
+++ b/2010/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/14/index.html
+++ b/2010/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/15/index.html
+++ b/2010/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/16/index.html
+++ b/2010/page/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/17/index.html
+++ b/2010/page/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/18/index.html
+++ b/2010/page/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/19/index.html
+++ b/2010/page/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/2/index.html
+++ b/2010/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/20/index.html
+++ b/2010/page/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/21/index.html
+++ b/2010/page/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/22/index.html
+++ b/2010/page/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/23/index.html
+++ b/2010/page/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/24/index.html
+++ b/2010/page/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/25/index.html
+++ b/2010/page/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/26/index.html
+++ b/2010/page/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/27/index.html
+++ b/2010/page/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/28/index.html
+++ b/2010/page/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/3/index.html
+++ b/2010/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/4/index.html
+++ b/2010/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/5/index.html
+++ b/2010/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/6/index.html
+++ b/2010/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/7/index.html
+++ b/2010/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/8/index.html
+++ b/2010/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2010/page/9/index.html
+++ b/2010/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/03/back-in-italy-back-to-work/index.html
+++ b/2011/01/03/back-in-italy-back-to-work/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/03/index.html
+++ b/2011/01/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/04/index.html
+++ b/2011/01/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/04/opensuse-board-about-my-application/index.html
+++ b/2011/01/04/opensuse-board-about-my-application/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/11/index.html
+++ b/2011/01/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/11/the-first-days-of-2011/index.html
+++ b/2011/01/11/the-first-days-of-2011/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/13/index.html
+++ b/2011/01/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/13/opensuse-factory-ati-firegl-10-12/index.html
+++ b/2011/01/13/opensuse-factory-ati-firegl-10-12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/13/wallpaper-community-pack-1/index.html
+++ b/2011/01/13/wallpaper-community-pack-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/17/a-brief-update/index.html
+++ b/2011/01/17/a-brief-update/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/17/index.html
+++ b/2011/01/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/17/questions-for-board-applicants/index.html
+++ b/2011/01/17/questions-for-board-applicants/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/19/configuring-an-ipv6-dsl-connection/index.html
+++ b/2011/01/19/configuring-an-ipv6-dsl-connection/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/19/index.html
+++ b/2011/01/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/19/kde-release-party-in-madrid-2nd-edition/index.html
+++ b/2011/01/19/kde-release-party-in-madrid-2nd-edition/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/19/welcome-to-bita-2011/index.html
+++ b/2011/01/19/welcome-to-bita-2011/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/20/index.html
+++ b/2011/01/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/20/massive-update-on-ubuntu-software/index.html
+++ b/2011/01/20/massive-update-on-ubuntu-software/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/20/openqa-is-testing-for-you/index.html
+++ b/2011/01/20/openqa-is-testing-for-you/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/21/index.html
+++ b/2011/01/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/21/libreoffice-3-3-rc4-available-for-opensuse/index.html
+++ b/2011/01/21/libreoffice-3-3-rc4-available-for-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/22/index.html
+++ b/2011/01/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/22/unity-compiz-and-ati/index.html
+++ b/2011/01/22/unity-compiz-and-ati/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/24/index.html
+++ b/2011/01/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/24/oxygenise-your-apache/index.html
+++ b/2011/01/24/oxygenise-your-apache/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/25/index.html
+++ b/2011/01/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/25/share-your-kraft/index.html
+++ b/2011/01/25/share-your-kraft/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/27/6481/index.html
+++ b/2011/01/27/6481/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/27/a-heartly-thank-you/index.html
+++ b/2011/01/27/a-heartly-thank-you/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/27/index.html
+++ b/2011/01/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/28/boo/index.html
+++ b/2011/01/28/boo/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/28/index.html
+++ b/2011/01/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/30/index.html
+++ b/2011/01/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/30/new-osc-feature-to-edit-a-request/index.html
+++ b/2011/01/30/new-osc-feature-to-edit-a-request/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/30/unity-on-opensuse-update/index.html
+++ b/2011/01/30/unity-on-opensuse-update/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/31/index.html
+++ b/2011/01/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/31/superficial-notes-on-interpersonal-relations/index.html
+++ b/2011/01/31/superficial-notes-on-interpersonal-relations/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/31/synapse-semantic-launcher-for-gnome/index.html
+++ b/2011/01/31/synapse-semantic-launcher-for-gnome/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/index.html
+++ b/2011/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/page/2/index.html
+++ b/2011/01/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/01/page/3/index.html
+++ b/2011/01/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/03/a-simple-clock-indicator-indicator-datetime/index.html
+++ b/2011/02/03/a-simple-clock-indicator-indicator-datetime/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/03/index.html
+++ b/2011/02/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/03/join-us-for-the-first-virtual-launch-party-opensuse-11-4/index.html
+++ b/2011/02/03/join-us-for-the-first-virtual-launch-party-opensuse-11-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/05/index.html
+++ b/2011/02/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/05/notify-osd-in-opensuse-11-4/index.html
+++ b/2011/02/05/notify-osd-in-opensuse-11-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/07/appmenu-gtk-and-indicator-appmenu/index.html
+++ b/2011/02/07/appmenu-gtk-and-indicator-appmenu/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/07/index.html
+++ b/2011/02/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/09/how-to-work-with-obs-via-slow-connections/index.html
+++ b/2011/02/09/how-to-work-with-obs-via-slow-connections/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/09/index.html
+++ b/2011/02/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/09/libreoffice-3-3-0-final-available-for-opensuse/index.html
+++ b/2011/02/09/libreoffice-3-3-0-final-available-for-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/11/index.html
+++ b/2011/02/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/11/open-hardware-definition-goes-1-0/index.html
+++ b/2011/02/11/open-hardware-definition-goes-1-0/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/13/ati-amd-flgrx-8-812-catalyst-11-1-available-also-for-11-4factory/index.html
+++ b/2011/02/13/ati-amd-flgrx-8-812-catalyst-11-1-available-also-for-11-4factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/13/index.html
+++ b/2011/02/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/14/index.html
+++ b/2011/02/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/14/virtual-launch-party-for-opensuse-11-4-rc1-is-done/index.html
+++ b/2011/02/14/virtual-launch-party-for-opensuse-11-4-rc1-is-done/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/15/abandoning-unity-for-the-time-being/index.html
+++ b/2011/02/15/abandoning-unity-for-the-time-being/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/15/index.html
+++ b/2011/02/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/19/index.html
+++ b/2011/02/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/19/indicators-for-gnome2-update/index.html
+++ b/2011/02/19/indicators-for-gnome2-update/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/20/gnomeayatana-project-page-in-english-and-portuguese/index.html
+++ b/2011/02/20/gnomeayatana-project-page-in-english-and-portuguese/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/20/index.html
+++ b/2011/02/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/21/default-wallpaper-for-gnomeayatana/index.html
+++ b/2011/02/21/default-wallpaper-for-gnomeayatana/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/21/index.html
+++ b/2011/02/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/22/10-good-reasons-for-upgrading-to-opensuse-11-4/index.html
+++ b/2011/02/22/10-good-reasons-for-upgrading-to-opensuse-11-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/22/index.html
+++ b/2011/02/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/24/flisol-2011/index.html
+++ b/2011/02/24/flisol-2011/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/24/index.html
+++ b/2011/02/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/index.html
+++ b/2011/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/02/page/2/index.html
+++ b/2011/02/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/01/index.html
+++ b/2011/03/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/01/libreoffice-3-3-1-bugfix-release-available-for-opensuse/index.html
+++ b/2011/03/01/libreoffice-3-3-1-bugfix-release-available-for-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/01/opensuse-in-etec-of-bebedourobrazil/index.html
+++ b/2011/03/01/opensuse-in-etec-of-bebedourobrazil/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/02/index.html
+++ b/2011/03/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/02/the-portuguese-republic-citizens-card-and-opensuse/index.html
+++ b/2011/03/02/the-portuguese-republic-citizens-card-and-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/05/index.html
+++ b/2011/03/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/05/sinclair-zx-spectrum-30-years/index.html
+++ b/2011/03/05/sinclair-zx-spectrum-30-years/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/06/index.html
+++ b/2011/03/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="license implications when packaging non-OSI approved software TrueCrypt for openSUSE" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/06/license-implications-when-packaging-truecrypt/index.html
+++ b/2011/03/06/license-implications-when-packaging-truecrypt/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="license implications when packaging non-OSI approved software TrueCrypt for openSUSE" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/08/index.html
+++ b/2011/03/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/08/some-updates-on-the-indicator-stack/index.html
+++ b/2011/03/08/some-updates-on-the-indicator-stack/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/10/gnome-shell-test-drive/index.html
+++ b/2011/03/10/gnome-shell-test-drive/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/10/index.html
+++ b/2011/03/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/10/virtual-party-its-now-eat-my-geekos-cake/index.html
+++ b/2011/03/10/virtual-party-its-now-eat-my-geekos-cake/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/11/how-to-name-the-distribution-releases/index.html
+++ b/2011/03/11/how-to-name-the-distribution-releases/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/11/index.html
+++ b/2011/03/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/13/index.html
+++ b/2011/03/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/13/opensuse-11-4-how-it-goes-in-portugal/index.html
+++ b/2011/03/13/opensuse-11-4-how-it-goes-in-portugal/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/15/index.html
+++ b/2011/03/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/15/opensuse-11-4-wine-a-practical-case/index.html
+++ b/2011/03/15/opensuse-11-4-wine-a-practical-case/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/16/first-survey-on-opensuse-version-naming-is-open-now/index.html
+++ b/2011/03/16/first-survey-on-opensuse-version-naming-is-open-now/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/16/index.html
+++ b/2011/03/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/17/index.html
+++ b/2011/03/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/17/opensuse-and-kraft-on-clt/index.html
+++ b/2011/03/17/opensuse-and-kraft-on-clt/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/18/index.html
+++ b/2011/03/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/18/temporary-overwrite-method-for-specific-task/index.html
+++ b/2011/03/18/temporary-overwrite-method-for-specific-task/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/21/index.html
+++ b/2011/03/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/21/policy-proposal-for-factory-make-source-of-tar-balls-trackable/index.html
+++ b/2011/03/21/policy-proposal-for-factory-make-source-of-tar-balls-trackable/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/22/index.html
+++ b/2011/03/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/22/securing-ssh-secure-shell-from-brute-force-attempts/index.html
+++ b/2011/03/22/securing-ssh-secure-shell-from-brute-force-attempts/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/23/chemnitzer-linuxtage-2011/index.html
+++ b/2011/03/23/chemnitzer-linuxtage-2011/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/23/distro-competition-sessions-needed/index.html
+++ b/2011/03/23/distro-competition-sessions-needed/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/23/index.html
+++ b/2011/03/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/23/osc-plugin-changes/index.html
+++ b/2011/03/23/osc-plugin-changes/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/24/gsoc-idea-build-service-plasma-widget-suite/index.html
+++ b/2011/03/24/gsoc-idea-build-service-plasma-widget-suite/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/24/gsoc-idea-improve-clic-filesystem/index.html
+++ b/2011/03/24/gsoc-idea-improve-clic-filesystem/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/24/index.html
+++ b/2011/03/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/25/index.html
+++ b/2011/03/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/25/libreoffice-3-3-2-bugfix-release-available-for-opensuse/index.html
+++ b/2011/03/25/libreoffice-3-3-2-bugfix-release-available-for-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/27/index.html
+++ b/2011/03/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/27/open-hardware-logo-selection-underway/index.html
+++ b/2011/03/27/open-hardware-logo-selection-underway/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/28/index.html
+++ b/2011/03/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/28/opensuse-release-versioning-poll-on-last-three-options/index.html
+++ b/2011/03/28/opensuse-release-versioning-poll-on-last-three-options/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/29/index.html
+++ b/2011/03/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="openSUSE Education team is proud to present openSUSE Edu Li-f-e (Linux for Education) based on openSUSE 11.4. The aim of this DVD is to provide complete education and development resources for parents, students, teachers as well as IT admins running labs at educational institutes." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/29/opensuse-edu-li-f-e-11-4-out-now/index.html
+++ b/2011/03/29/opensuse-edu-li-f-e-11-4-out-now/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="openSUSE Education team is proud to present openSUSE Edu Li-f-e (Linux for Education) based on openSUSE 11.4. The aim of this DVD is to provide complete education and development resources for parents, students, teachers as well as IT admins running labs at educational institutes." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/30/gnomeayatana-being-populated/index.html
+++ b/2011/03/30/gnomeayatana-being-populated/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/30/index.html
+++ b/2011/03/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/index.html
+++ b/2011/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/page/2/index.html
+++ b/2011/03/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/03/page/3/index.html
+++ b/2011/03/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/01/index.html
+++ b/2011/04/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/01/introducing-snapper/index.html
+++ b/2011/04/01/introducing-snapper/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/03/atiamd-fglrx-8-831-catalyst-11-3-available-for-opensuse-11-2-11-3-11-4/index.html
+++ b/2011/04/03/atiamd-fglrx-8-831-catalyst-11-3-available-for-opensuse-11-2-11-3-11-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/03/index.html
+++ b/2011/04/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/04/a-kind-word-to-everyone/index.html
+++ b/2011/04/04/a-kind-word-to-everyone/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/04/freebeer-ch-version-2-0-new-taste-new-packaging-same-free-license/index.html
+++ b/2011/04/04/freebeer-ch-version-2-0-new-taste-new-packaging-same-free-license/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/04/index.html
+++ b/2011/04/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/06/gnome-3-launch-party-friday-8th-april-in-zurich-join-us/index.html
+++ b/2011/04/06/gnome-3-launch-party-friday-8th-april-in-zurich-join-us/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/06/index.html
+++ b/2011/04/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/06/versionitis/index.html
+++ b/2011/04/06/versionitis/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/09/index.html
+++ b/2011/04/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/09/opensuse-11-4-cheat-sheet-poster-dvd-in-linux-magazine/index.html
+++ b/2011/04/09/opensuse-11-4-cheat-sheet-poster-dvd-in-linux-magazine/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-iso-by-fcrozat-and-ati-radeon-driver-a-quick-easy-fix/index.html
+++ b/2011/04/10/gnome3-iso-by-fcrozat-and-ati-radeon-driver-a-quick-easy-fix/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/gnome3_zurich/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/gnome3_zurich/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="ETHZ building" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/gnome3_zurich_bf/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/gnome3_zurich_bf/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide01/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Gnome 3 - Your new Linux Desktop" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide02/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="New features - made it easy" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide03/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="no window decoration, no taskbar" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide04/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Gnome 3 on Fedora" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide05/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Gnome 3 on openSUSE 11.4" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide06/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Gnome 3 application launcher " />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide07/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Gnome 3 application launcher Firefox" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide08/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Activity window" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide09/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="system tray &#38; notification" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide10/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Notifiaction popups" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide11/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Application start a way to replace traditionnal menu" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide12/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Redisigned workspace &#38; better user interface" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide13/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Conclusions" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/gnome3-launch-party-zurich-report/slide14/index.html
+++ b/2011/04/10/gnome3-launch-party-zurich-report/slide14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Thanks" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/10/index.html
+++ b/2011/04/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/15/calibre-repository-moved/index.html
+++ b/2011/04/15/calibre-repository-moved/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/15/index.html
+++ b/2011/04/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="This gives some thoughts to problems with our bugzilla and ways to better track our bugs." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/15/where-our-bugzilla-needs-improvement/index.html
+++ b/2011/04/15/where-our-bugzilla-needs-improvement/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="This gives some thoughts to problems with our bugzilla and ways to better track our bugs." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/25/fosscomm-2011-in-patras-greece/index.html
+++ b/2011/04/25/fosscomm-2011-in-patras-greece/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/25/index.html
+++ b/2011/04/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/25/the-dreamchess-incident/index.html
+++ b/2011/04/25/the-dreamchess-incident/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/26/index.html
+++ b/2011/04/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/26/subversion-with-libserf/index.html
+++ b/2011/04/26/subversion-with-libserf/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/30/index.html
+++ b/2011/04/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/30/mockup-gnome3-and-yast/index.html
+++ b/2011/04/30/mockup-gnome3-and-yast/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/index.html
+++ b/2011/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/04/page/2/index.html
+++ b/2011/04/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/03/amdati-catalyst-11-4-pre-build-package-next-week/index.html
+++ b/2011/05/03/amdati-catalyst-11-4-pre-build-package-next-week/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/03/index.html
+++ b/2011/05/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/03/vintage/index.html
+++ b/2011/05/03/vintage/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/05/gpick-an-advanced-color-picker/index.html
+++ b/2011/05/05/gpick-an-advanced-color-picker/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/05/index.html
+++ b/2011/05/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/06/index.html
+++ b/2011/05/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/06/opensuse-11-4-built-to-rule-gnome/index.html
+++ b/2011/05/06/opensuse-11-4-built-to-rule-gnome/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/09/index.html
+++ b/2011/05/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/09/unknown-horizons-a-nice-strategy-game-now-on-opensuse/index.html
+++ b/2011/05/09/unknown-horizons-a-nice-strategy-game-now-on-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/14/atiamd-fglrx-8-850-catalyst-11-5-available-for-opensuse-11-2-11-3-11-4-factory/index.html
+++ b/2011/05/14/atiamd-fglrx-8-850-catalyst-11-5-available-for-opensuse-11-2-11-3-11-4-factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/14/index.html
+++ b/2011/05/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/16/have-you-burped-yet-today/index.html
+++ b/2011/05/16/have-you-burped-yet-today/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/16/index.html
+++ b/2011/05/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/16/opensuse-on-the-linuxtag-2011/index.html
+++ b/2011/05/16/opensuse-on-the-linuxtag-2011/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/16/wine-on-linuxtag-2011/index.html
+++ b/2011/05/16/wine-on-linuxtag-2011/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Brief report on the Wine talk at LinuxTag 2011 in Berlin, by Christian Boltz and Marcus Meissner. " />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/17/advancing-with-gnomeayatana-repository/index.html
+++ b/2011/05/17/advancing-with-gnomeayatana-repository/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/17/index.html
+++ b/2011/05/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/18/a-few-improvements/index.html
+++ b/2011/05/18/a-few-improvements/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/18/index.html
+++ b/2011/05/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/19/index.html
+++ b/2011/05/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/19/unity-2d-to-enter-gnomeayatana-soon/index.html
+++ b/2011/05/19/unity-2d-to-enter-gnomeayatana-soon/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/23/gsoc-new-osc-user-interface-proposal/index.html
+++ b/2011/05/23/gsoc-new-osc-user-interface-proposal/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/23/index.html
+++ b/2011/05/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/25/index.html
+++ b/2011/05/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/25/libreoffice-and-european-portuguese/index.html
+++ b/2011/05/25/libreoffice-and-european-portuguese/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/26/7393/index.html
+++ b/2011/05/26/7393/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/26/index.html
+++ b/2011/05/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/27/factory-progress/index.html
+++ b/2011/05/27/factory-progress/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/27/index.html
+++ b/2011/05/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/28/gsoc-summary-of-week-1/index.html
+++ b/2011/05/28/gsoc-summary-of-week-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/28/index.html
+++ b/2011/05/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/31/index.html
+++ b/2011/05/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/31/some-updates-on-the-banshee-repositories/index.html
+++ b/2011/05/31/some-updates-on-the-banshee-repositories/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/index.html
+++ b/2011/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/05/page/2/index.html
+++ b/2011/05/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/03/factory-progress-2011-06-03/index.html
+++ b/2011/06/03/factory-progress-2011-06-03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/03/gsoc-summary-of-week-2/index.html
+++ b/2011/06/03/gsoc-summary-of-week-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/03/index.html
+++ b/2011/06/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/06/bee-keeping-catch-a-swarm/index.html
+++ b/2011/06/06/bee-keeping-catch-a-swarm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/06/index.html
+++ b/2011/06/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/10/gsoc-summary-of-week-3/index.html
+++ b/2011/06/10/gsoc-summary-of-week-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/10/index.html
+++ b/2011/06/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/17/atiamd-fglrx-8-861-catalyst-11-6-available-for-opensuse-11-2-11-3-11-4-factory/index.html
+++ b/2011/06/17/atiamd-fglrx-8-861-catalyst-11-6-available-for-opensuse-11-2-11-3-11-4-factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/17/index.html
+++ b/2011/06/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/19/aux-armes-citoyens-et-cetera/index.html
+++ b/2011/06/19/aux-armes-citoyens-et-cetera/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/19/gsoc-osc-code-cleanup-summary-of-week-4/index.html
+++ b/2011/06/19/gsoc-osc-code-cleanup-summary-of-week-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/19/index.html
+++ b/2011/06/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/20/1-2-3-cloud/index.html
+++ b/2011/06/20/1-2-3-cloud/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/20/index.html
+++ b/2011/06/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/21/index.html
+++ b/2011/06/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/21/libreoffice-3-3-3-bugfix-release-available-for-opensuse/index.html
+++ b/2011/06/21/libreoffice-3-3-3-bugfix-release-available-for-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/26/gsoc-osc-code-cleanup-–-summary-of-week-5/index.html
+++ b/2011/06/26/gsoc-osc-code-cleanup-–-summary-of-week-5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/26/index.html
+++ b/2011/06/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/27/facebook-bans-kdes-photo-uploaded-all-uploaded-content-inaccessible/index.html
+++ b/2011/06/27/facebook-bans-kdes-photo-uploaded-all-uploaded-content-inaccessible/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/27/index.html
+++ b/2011/06/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/index.html
+++ b/2011/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/06/page/2/index.html
+++ b/2011/06/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/01/factory-progress-2011-07-01/index.html
+++ b/2011/07/01/factory-progress-2011-07-01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/01/index.html
+++ b/2011/07/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/04/gsoc-osc-code-cleanup-–-summary-of-week-6/index.html
+++ b/2011/07/04/gsoc-osc-code-cleanup-–-summary-of-week-6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/04/index.html
+++ b/2011/07/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/09/index.html
+++ b/2011/07/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/09/open-hardware-license-released-by-cern/index.html
+++ b/2011/07/09/open-hardware-license-released-by-cern/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/10/gsoc-osc-code-cleanup-summary-of-week-7/index.html
+++ b/2011/07/10/gsoc-osc-code-cleanup-summary-of-week-7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/10/index.html
+++ b/2011/07/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/11/index.html
+++ b/2011/07/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/11/presentation-resolution-on-netbooks/index.html
+++ b/2011/07/11/presentation-resolution-on-netbooks/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/12/index.html
+++ b/2011/07/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/12/zippl-again-now-in-the-package/index.html
+++ b/2011/07/12/zippl-again-now-in-the-package/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/14/improved-kernel-package-retention-in-12-1/index.html
+++ b/2011/07/14/improved-kernel-package-retention-in-12-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/14/index.html
+++ b/2011/07/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/17/gsoc-osc-code-cleanup-–-summary-of-week-8/index.html
+++ b/2011/07/17/gsoc-osc-code-cleanup-–-summary-of-week-8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/17/index.html
+++ b/2011/07/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/17/new-package-squidview-available/index.html
+++ b/2011/07/17/new-package-squidview-available/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/17/steampunk-beautiful-theme-for-kdm-and-ksplash/index.html
+++ b/2011/07/17/steampunk-beautiful-theme-for-kdm-and-ksplash/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/18/factory-progress-2011-07-18/index.html
+++ b/2011/07/18/factory-progress-2011-07-18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/18/index.html
+++ b/2011/07/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/19/index.html
+++ b/2011/07/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/19/lxde-and-gtk3/index.html
+++ b/2011/07/19/lxde-and-gtk3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/19/new-namespace-for-kde-apps-maintained-by-upstream/index.html
+++ b/2011/07/19/new-namespace-for-kde-apps-maintained-by-upstream/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/29/index.html
+++ b/2011/07/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/29/volunteers-needed/index.html
+++ b/2011/07/29/volunteers-needed/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/index.html
+++ b/2011/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/07/page/2/index.html
+++ b/2011/07/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/01/atiamd-fglrx-8-872-catalyst-11-7-available-for-opensuse-11-3-11-4-12-1-factory/index.html
+++ b/2011/08/01/atiamd-fglrx-8-872-catalyst-11-7-available-for-opensuse-11-3-11-4-12-1-factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/01/gsoc-osc-code-cleanup-summary-of-week-10/index.html
+++ b/2011/08/01/gsoc-osc-code-cleanup-summary-of-week-10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/01/index.html
+++ b/2011/08/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/03/index.html
+++ b/2011/08/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/03/mounting-usr-in-the-initrd/index.html
+++ b/2011/08/03/mounting-usr-in-the-initrd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/05/factory-progress-2011-08-05/index.html
+++ b/2011/08/05/factory-progress-2011-08-05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/05/index.html
+++ b/2011/08/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/08/gsoc-osc-code-cleanup-summary-of-week-11/index.html
+++ b/2011/08/08/gsoc-osc-code-cleanup-summary-of-week-11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/08/index.html
+++ b/2011/08/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/12/index.html
+++ b/2011/08/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/12/looking-for-artists-artworks-and-graphics-for-lxde/index.html
+++ b/2011/08/12/looking-for-artists-artworks-and-graphics-for-lxde/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/15/desktop-summit-berlin-2011-report/index.html
+++ b/2011/08/15/desktop-summit-berlin-2011-report/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/15/index.html
+++ b/2011/08/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/17/index.html
+++ b/2011/08/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/17/opensuse-conference-2011-schedule-available/index.html
+++ b/2011/08/17/opensuse-conference-2011-schedule-available/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/19/index.html
+++ b/2011/08/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/19/opensuse-lxde-logo-contest-starting-now/index.html
+++ b/2011/08/19/opensuse-lxde-logo-contest-starting-now/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/20/atiamd-fglrx-8-881-catalyst-11-8-available-for-opensuse-11-3-11-4-12-1-factory/index.html
+++ b/2011/08/20/atiamd-fglrx-8-881-catalyst-11-8-available-for-opensuse-11-3-11-4-12-1-factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/20/index.html
+++ b/2011/08/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/22/index.html
+++ b/2011/08/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/22/opensuse-conference-2011-straight-from-the-lab/index.html
+++ b/2011/08/22/opensuse-conference-2011-straight-from-the-lab/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/index.html
+++ b/2011/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/08/page/2/index.html
+++ b/2011/08/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/01/atiamd-flgrx-status-of-the-helping-pledge/index.html
+++ b/2011/09/01/atiamd-flgrx-status-of-the-helping-pledge/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/01/index.html
+++ b/2011/09/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/05/fsck-ocfs2-io-error-on-channel-while-performing-pass-1/index.html
+++ b/2011/09/05/fsck-ocfs2-io-error-on-channel-while-performing-pass-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/05/index.html
+++ b/2011/09/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/10/ar-drone-with-opencv-in-the-opensuse-11-4/index.html
+++ b/2011/09/10/ar-drone-with-opencv-in-the-opensuse-11-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/10/index.html
+++ b/2011/09/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/11/index.html
+++ b/2011/09/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/11/thoughts-about-using-test-driven-development-for-my-gsoc-project/index.html
+++ b/2011/09/11/thoughts-about-using-test-driven-development-for-my-gsoc-project/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/15/index.html
+++ b/2011/09/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/15/libreoffice-3-4-available-for-opensuse/index.html
+++ b/2011/09/15/libreoffice-3-4-available-for-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/18/education-at-osc/index.html
+++ b/2011/09/18/education-at-osc/index.html
@@ -23,15 +23,10 @@
 I like to give a very subjective overview about the current state, so the rumors have something to eat ;-)" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/18/index.html
+++ b/2011/09/18/index.html
@@ -23,15 +23,10 @@
 I like to give a very subjective overview about the current state, so the rumors have something to eat ;-)" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/19/index.html
+++ b/2011/09/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/19/osc11-slides-and-screen-cast-workshop-kvmlibvirtd/index.html
+++ b/2011/09/19/osc11-slides-and-screen-cast-workshop-kvmlibvirtd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/21/index.html
+++ b/2011/09/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/21/openfate-news/index.html
+++ b/2011/09/21/openfate-news/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/22/happy-pony-opensuse/index.html
+++ b/2011/09/22/happy-pony-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/22/index.html
+++ b/2011/09/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/09/index.html
+++ b/2011/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/10/02/atiamd-fglrx-8-892-catalyst-11-9-available-for-opensuse-11-3-11-4-12-1-factory/index.html
+++ b/2011/10/02/atiamd-fglrx-8-892-catalyst-11-9-available-for-opensuse-11-3-11-4-12-1-factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/10/02/index.html
+++ b/2011/10/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/10/03/3-new-virtual-party-on-secondlife-for-upcoming-opensuse-12-1/index.html
+++ b/2011/10/03/3-new-virtual-party-on-secondlife-for-upcoming-opensuse-12-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/10/03/index.html
+++ b/2011/10/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/10/09/geeko-says-hey-dude-thats-my-car/index.html
+++ b/2011/10/09/geeko-says-hey-dude-thats-my-car/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/10/09/index.html
+++ b/2011/10/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/10/21/index.html
+++ b/2011/10/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/10/21/nobody-should-live-without-their-geeko-plushie/index.html
+++ b/2011/10/21/nobody-should-live-without-their-geeko-plushie/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/10/24/index.html
+++ b/2011/10/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/10/24/new-style-for-yast2/index.html
+++ b/2011/10/24/new-style-for-yast2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/10/index.html
+++ b/2011/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/11/05/atiamd-fglrx-8-902-catalyst-11-10-available-for-opensuse-11-3-11-4-12-1-factory/index.html
+++ b/2011/11/05/atiamd-fglrx-8-902-catalyst-11-10-available-for-opensuse-11-3-11-4-12-1-factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/11/05/index.html
+++ b/2011/11/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/11/07/index.html
+++ b/2011/11/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/11/07/webyast-0-3-is-out/index.html
+++ b/2011/11/07/webyast-0-3-is-out/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/11/12/gold-master-release-is-starting-in-5-minutes/index.html
+++ b/2011/11/12/gold-master-release-is-starting-in-5-minutes/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/11/12/index.html
+++ b/2011/11/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/11/16/index.html
+++ b/2011/11/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/11/16/kde-telepathy-one-click-install/index.html
+++ b/2011/11/16/kde-telepathy-one-click-install/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/11/16/webyast-terminal-plugin/index.html
+++ b/2011/11/16/webyast-terminal-plugin/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/11/21/atiamd-fglrx-8-911-catalyst-11-11-rpm-available-for-opensuse-11-3-11-4-12-1/index.html
+++ b/2011/11/21/atiamd-fglrx-8-911-catalyst-11-11-rpm-available-for-opensuse-11-3-11-4-12-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/11/21/index.html
+++ b/2011/11/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/11/index.html
+++ b/2011/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/02/index.html
+++ b/2011/12/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/02/opensuse-12-1-kde3-livecd/index.html
+++ b/2011/12/02/opensuse-12-1-kde3-livecd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/05/gnome-2-under-opensuse-12-1/index.html
+++ b/2011/12/05/gnome-2-under-opensuse-12-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/05/index.html
+++ b/2011/12/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/07/cooking-with-docbook/index.html
+++ b/2011/12/07/cooking-with-docbook/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/07/index.html
+++ b/2011/12/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/08/index.html
+++ b/2011/12/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/08/the-exo-typeface-family/index.html
+++ b/2011/12/08/the-exo-typeface-family/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/10/index.html
+++ b/2011/12/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/10/opensuse-board-election-my-manifesto/index.html
+++ b/2011/12/10/opensuse-board-election-my-manifesto/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/12/index.html
+++ b/2011/12/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/12/opensuse-12-1-gnome-2-livecd-is-available/index.html
+++ b/2011/12/12/opensuse-12-1-gnome-2-livecd-is-available/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/18/index.html
+++ b/2011/12/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/18/opensuse-12-1-kde3-livedvd-is-ready/index.html
+++ b/2011/12/18/opensuse-12-1-kde3-livedvd-is-ready/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/21/how-to-be-user-friendly/index.html
+++ b/2011/12/21/how-to-be-user-friendly/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/21/index.html
+++ b/2011/12/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/22/edu-li-f-e-12-1-out/index.html
+++ b/2011/12/22/edu-li-f-e-12-1-out/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/22/index.html
+++ b/2011/12/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/29/cinnamon-on-opensuse/index.html
+++ b/2011/12/29/cinnamon-on-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/29/index.html
+++ b/2011/12/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/12/index.html
+++ b/2011/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/index.html
+++ b/2011/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/10/index.html
+++ b/2011/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/11/index.html
+++ b/2011/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/12/index.html
+++ b/2011/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/13/index.html
+++ b/2011/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/14/index.html
+++ b/2011/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/15/index.html
+++ b/2011/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/16/index.html
+++ b/2011/page/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/17/index.html
+++ b/2011/page/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/2/index.html
+++ b/2011/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/3/index.html
+++ b/2011/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/4/index.html
+++ b/2011/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/5/index.html
+++ b/2011/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/6/index.html
+++ b/2011/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/7/index.html
+++ b/2011/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/8/index.html
+++ b/2011/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2011/page/9/index.html
+++ b/2011/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/01/19/fuk-the-kit-you-will-love/index.html
+++ b/2012/01/19/fuk-the-kit-you-will-love/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/01/19/index.html
+++ b/2012/01/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/01/19/running-opensuse-on-arm/index.html
+++ b/2012/01/19/running-opensuse-on-arm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/01/21/index.html
+++ b/2012/01/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/01/21/opensuse-arm-image/index.html
+++ b/2012/01/21/opensuse-arm-image/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/01/22/index.html
+++ b/2012/01/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/01/22/winter-outside-summer-inside-keep-geekos-head-warm/index.html
+++ b/2012/01/22/winter-outside-summer-inside-keep-geekos-head-warm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/01/27/atiamd-fglrx-8-930-catalyst-12-1-rpm-available-for-opensuse-11-3-11-4-12-1/index.html
+++ b/2012/01/27/atiamd-fglrx-8-930-catalyst-12-1-rpm-available-for-opensuse-11-3-11-4-12-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/01/27/index.html
+++ b/2012/01/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/01/index.html
+++ b/2012/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/02/15/index.html
+++ b/2012/02/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/02/15/yast-next-step-in-system-management/index.html
+++ b/2012/02/15/yast-next-step-in-system-management/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/02/20/index.html
+++ b/2012/02/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/02/20/opensuse-at-bita2012/index.html
+++ b/2012/02/20/opensuse-at-bita2012/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/02/index.html
+++ b/2012/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/03/02/index.html
+++ b/2012/03/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/03/02/kde-3-got-upower-support-and-more/index.html
+++ b/2012/03/02/kde-3-got-upower-support-and-more/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/03/08/atiamd-fglrx-8-950-catalyst-12-2-rpm-available-for-opensuse-11-3-11-4-12-1/index.html
+++ b/2012/03/08/atiamd-fglrx-8-950-catalyst-12-2-rpm-available-for-opensuse-11-3-11-4-12-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/03/08/index.html
+++ b/2012/03/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/03/15/index.html
+++ b/2012/03/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/03/15/subversion-with-libserf-continued/index.html
+++ b/2012/03/15/subversion-with-libserf-continued/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/03/30/amdati-fglrx-8-951-catalyst-12-3-rpms-available-for-opensuse-12-2-12-1-11-4-11-3/index.html
+++ b/2012/03/30/amdati-fglrx-8-951-catalyst-12-3-rpms-available-for-opensuse-12-2-12-1-11-4-11-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/03/30/index.html
+++ b/2012/03/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/03/30/new-package-postgresql-plr-get-the-power-of-r-inside-your-postgresql-database/index.html
+++ b/2012/03/30/new-package-postgresql-plr-get-the-power-of-r-inside-your-postgresql-database/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/03/index.html
+++ b/2012/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/04/04/index.html
+++ b/2012/04/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/04/04/kde48/index.html
+++ b/2012/04/04/kde48/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/04/09/index.html
+++ b/2012/04/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/04/09/opensuse-12-1-multimedia-built-on-susestudio/index.html
+++ b/2012/04/09/opensuse-12-1-multimedia-built-on-susestudio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/04/10/index.html
+++ b/2012/04/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/04/10/libreoffice-3-5-available-for-testing-on-opensuse/index.html
+++ b/2012/04/10/libreoffice-3-5-available-for-testing-on-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/04/18/cli-to-upload-image-to-openstack-cloud/index.html
+++ b/2012/04/18/cli-to-upload-image-to-openstack-cloud/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/04/18/index.html
+++ b/2012/04/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/04/index.html
+++ b/2012/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/05/17/index.html
+++ b/2012/05/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/05/17/opensuse-in-education-spreading-continue/index.html
+++ b/2012/05/17/opensuse-in-education-spreading-continue/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/05/21/a-new-font-repository/index.html
+++ b/2012/05/21/a-new-font-repository/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/05/21/index.html
+++ b/2012/05/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/05/24/index.html
+++ b/2012/05/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/05/24/ruby-why-use-symbols-in-hash-instead-of-strings-and-when-dont-do-it/index.html
+++ b/2012/05/24/ruby-why-use-symbols-in-hash-instead-of-strings-and-when-dont-do-it/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/05/31/amdati-fglrx-8-961-catalyst-12-4-build-5-rpms-available-for-opensuse-12-2-12-1-11-4-11-3-tumbleweed/index.html
+++ b/2012/05/31/amdati-fglrx-8-961-catalyst-12-4-build-5-rpms-available-for-opensuse-12-2-12-1-11-4-11-3-tumbleweed/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/05/31/index.html
+++ b/2012/05/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/05/index.html
+++ b/2012/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/02/index.html
+++ b/2012/06/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/02/kde3-gets-udisks2-backend/index.html
+++ b/2012/06/02/kde3-gets-udisks2-backend/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/04/gsoc-osc2-client-summary-of-week-1-and-2/index.html
+++ b/2012/06/04/gsoc-osc2-client-summary-of-week-1-and-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/04/index.html
+++ b/2012/06/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/07/index.html
+++ b/2012/06/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/07/new-blog/index.html
+++ b/2012/06/07/new-blog/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/19/gsoc-osc2-client-summary-of-week-3-and-4/index.html
+++ b/2012/06/19/gsoc-osc2-client-summary-of-week-3-and-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/19/index.html
+++ b/2012/06/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/26/gsoc-osc2-client-summary-of-week-5/index.html
+++ b/2012/06/26/gsoc-osc2-client-summary-of-week-5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/26/index.html
+++ b/2012/06/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/29/index.html
+++ b/2012/06/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/29/repository-gnomecontrib-is-dead/index.html
+++ b/2012/06/29/repository-gnomecontrib-is-dead/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/06/index.html
+++ b/2012/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/03/gsoc-osc2-client-summary-of-week-6/index.html
+++ b/2012/07/03/gsoc-osc2-client-summary-of-week-6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/03/index.html
+++ b/2012/07/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/11/gsoc-osc2-client-summary-of-week-7/index.html
+++ b/2012/07/11/gsoc-osc2-client-summary-of-week-7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/11/index.html
+++ b/2012/07/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/14/index.html
+++ b/2012/07/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/14/linux-kernel-built-with-clang-boots-into-opensuse/index.html
+++ b/2012/07/14/linux-kernel-built-with-clang-boots-into-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/16/gsoc-osc2-client-summary-of-week-8/index.html
+++ b/2012/07/16/gsoc-osc2-client-summary-of-week-8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/16/index.html
+++ b/2012/07/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/17/how-to-peek-into-remote-isos/index.html
+++ b/2012/07/17/how-to-peek-into-remote-isos/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/17/index.html
+++ b/2012/07/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/20/index.html
+++ b/2012/07/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/20/we-can-do-better/index.html
+++ b/2012/07/20/we-can-do-better/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/23/gsoc-osc2-client-summary-of-week-9/index.html
+++ b/2012/07/23/gsoc-osc2-client-summary-of-week-9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/23/index.html
+++ b/2012/07/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/25/index.html
+++ b/2012/07/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/25/snapper-lvm/index.html
+++ b/2012/07/25/snapper-lvm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/26/index.html
+++ b/2012/07/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/26/optimizing-a-boot-time-aka-2-second-boot/index.html
+++ b/2012/07/26/optimizing-a-boot-time-aka-2-second-boot/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/30/gsoc-osc2-client-summary-of-week-10/index.html
+++ b/2012/07/30/gsoc-osc2-client-summary-of-week-10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/30/index.html
+++ b/2012/07/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/31/amdati-catalyst-fglrx-fglrx-legacy-news/index.html
+++ b/2012/07/31/amdati-catalyst-fglrx-fglrx-legacy-news/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/31/index.html
+++ b/2012/07/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/31/optimizing-a-boot-time-aka-2-second-boot-part-2/index.html
+++ b/2012/07/31/optimizing-a-boot-time-aka-2-second-boot-part-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/index.html
+++ b/2012/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/07/page/2/index.html
+++ b/2012/07/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/08/07/gsoc-osc2-client-summary-of-week-11/index.html
+++ b/2012/08/07/gsoc-osc2-client-summary-of-week-11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/08/07/index.html
+++ b/2012/08/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/08/15/gsoc-osc2-client-summary-of-week-12/index.html
+++ b/2012/08/15/gsoc-osc2-client-summary-of-week-12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/08/15/index.html
+++ b/2012/08/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/08/16/index.html
+++ b/2012/08/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/08/16/osc2-syntax-update/index.html
+++ b/2012/08/16/osc2-syntax-update/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/08/23/index.html
+++ b/2012/08/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/08/23/testing-ltsp-on-opensuse-12-2/index.html
+++ b/2012/08/23/testing-ltsp-on-opensuse-12-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/08/31/editing-kiwi-configurations-with-emacs/index.html
+++ b/2012/08/31/editing-kiwi-configurations-with-emacs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/08/31/index.html
+++ b/2012/08/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/08/index.html
+++ b/2012/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/04/index.html
+++ b/2012/09/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/04/opensuse-conference-2012-how-to-build-rpms/index.html
+++ b/2012/09/04/opensuse-conference-2012-how-to-build-rpms/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/13/index.html
+++ b/2012/09/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/13/live-fat-stick/index.html
+++ b/2012/09/13/live-fat-stick/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/14/announcing-the-release-of-opensuse-edu-li-f-e-12-2/index.html
+++ b/2012/09/14/announcing-the-release-of-opensuse-edu-li-f-e-12-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/14/index.html
+++ b/2012/09/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/15/index.html
+++ b/2012/09/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/15/updates-for-opensuse-edu-li-f-e/index.html
+++ b/2012/09/15/updates-for-opensuse-edu-li-f-e/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/25/how-kiwi-can-help-to-cleanup-your-system/index.html
+++ b/2012/09/25/how-kiwi-can-help-to-cleanup-your-system/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/25/index.html
+++ b/2012/09/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/27/index.html
+++ b/2012/09/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/27/run-x2go-thin-client-using-kiwi-ltsp/index.html
+++ b/2012/09/27/run-x2go-thin-client-using-kiwi-ltsp/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/09/index.html
+++ b/2012/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/09/going-to-osc-12-wanna-a-place-in-the-most-geekys-car/index.html
+++ b/2012/10/09/going-to-osc-12-wanna-a-place-in-the-most-geekys-car/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/09/index.html
+++ b/2012/10/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/14/index.html
+++ b/2012/10/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/14/xtrabackup-for-mysql/index.html
+++ b/2012/10/14/xtrabackup-for-mysql/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/16/index.html
+++ b/2012/10/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/16/snapper-for-everyone/index.html
+++ b/2012/10/16/snapper-for-everyone/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/17/index.html
+++ b/2012/10/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/17/ot-shimano-alfine-11-di2-seis-and-backwards-compatibility-with-existing-hubs/index.html
+++ b/2012/10/17/ot-shimano-alfine-11-di2-seis-and-backwards-compatibility-with-existing-hubs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/20/index.html
+++ b/2012/10/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/20/osc12-its-started-already/index.html
+++ b/2012/10/20/osc12-its-started-already/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/28/amdati-fglrx-9-002-catalyst-12-10-released/index.html
+++ b/2012/10/28/amdati-fglrx-9-002-catalyst-12-10-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/28/index.html
+++ b/2012/10/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/10/index.html
+++ b/2012/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/12/17/index.html
+++ b/2012/12/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/12/17/new-osc-buildlog-strip-time-option/index.html
+++ b/2012/12/17/new-osc-buildlog-strip-time-option/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/12/27/index.html
+++ b/2012/12/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/12/27/livecds/index.html
+++ b/2012/12/27/livecds/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/12/29/index.html
+++ b/2012/12/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/12/29/making-different-opensuse-livecds/index.html
+++ b/2012/12/29/making-different-opensuse-livecds/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/12/index.html
+++ b/2012/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/index.html
+++ b/2012/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/page/2/index.html
+++ b/2012/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/page/3/index.html
+++ b/2012/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/page/4/index.html
+++ b/2012/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/page/5/index.html
+++ b/2012/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2012/page/6/index.html
+++ b/2012/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/01/11/index.html
+++ b/2013/01/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/01/11/openstack-on-opensuse/index.html
+++ b/2013/01/11/openstack-on-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/01/21/index.html
+++ b/2013/01/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/01/21/proprietary-amdati-catalyst-fglrx-13-1-9-012-1-rpm-released/index.html
+++ b/2013/01/21/proprietary-amdati-catalyst-fglrx-13-1-9-012-1-rpm-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/01/24/atiamd-catalyst-fglrx-legacy-updated-to-new-13-1-version/index.html
+++ b/2013/01/24/atiamd-catalyst-fglrx-legacy-updated-to-new-13-1-version/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/01/24/index.html
+++ b/2013/01/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/01/index.html
+++ b/2013/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/06/announcing-the-release-of-opensuse-edu-li-f-e-12-2-2/index.html
+++ b/2013/02/06/announcing-the-release-of-opensuse-edu-li-f-e-12-2-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/06/index.html
+++ b/2013/02/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/11/index.html
+++ b/2013/02/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/11/use-skype-4-10-with-opensuse-12-3-x86_64/index.html
+++ b/2013/02/11/use-skype-4-10-with-opensuse-12-3-x86_64/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/14/index.html
+++ b/2013/02/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/14/live-usb-gui/index.html
+++ b/2013/02/14/live-usb-gui/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/16/a-week-in-the-green-tail/index.html
+++ b/2013/02/16/a-week-in-the-green-tail/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/16/index.html
+++ b/2013/02/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/20/index.html
+++ b/2013/02/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/20/opensuse-on-phonestablets/index.html
+++ b/2013/02/20/opensuse-on-phonestablets/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/21/bita-2013-invite/index.html
+++ b/2013/02/21/bita-2013-invite/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/21/index.html
+++ b/2013/02/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/02/index.html
+++ b/2013/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/03/amd-fglrx-fgrlx-legacy-news-cleanup-important-informations/index.html
+++ b/2013/03/03/amd-fglrx-fgrlx-legacy-news-cleanup-important-informations/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/03/index.html
+++ b/2013/03/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/05/index.html
+++ b/2013/03/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/05/opensuse-12-3-image-available-for-arm64-aarch64/index.html
+++ b/2013/03/05/opensuse-12-3-image-available-for-arm64-aarch64/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/12/index.html
+++ b/2013/03/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/12/welcome-to-the-indian-reservation-ubuntu-gnomes/index.html
+++ b/2013/03/12/welcome-to-the-indian-reservation-ubuntu-gnomes/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/13/index.html
+++ b/2013/03/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/13/one-that-got-away-12-3-networking/index.html
+++ b/2013/03/13/one-that-got-away-12-3-networking/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/17/index.html
+++ b/2013/03/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/17/opensuse-12-3-12-2-and-nvidia-drivers/index.html
+++ b/2013/03/17/opensuse-12-3-12-2-and-nvidia-drivers/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/22/index.html
+++ b/2013/03/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/22/wxruby-is-now-on-buildservice/index.html
+++ b/2013/03/22/wxruby-is-now-on-buildservice/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/31/gpio-on-raspberry-pi/index.html
+++ b/2013/03/31/gpio-on-raspberry-pi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/31/index.html
+++ b/2013/03/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/03/index.html
+++ b/2013/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/04/06/index.html
+++ b/2013/04/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/04/06/tidy-home-tidy-build-service/index.html
+++ b/2013/04/06/tidy-home-tidy-build-service/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/04/11/hackweek9-lightweight-kde-desktop-project/index.html
+++ b/2013/04/11/hackweek9-lightweight-kde-desktop-project/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/04/11/index.html
+++ b/2013/04/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/04/15/apache-subversion-1-8-preview-packages/index.html
+++ b/2013/04/15/apache-subversion-1-8-preview-packages/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/04/15/index.html
+++ b/2013/04/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/04/29/index.html
+++ b/2013/04/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/04/29/proprietary-amdati-fglrx-12-104-catalyst-13-4-rpm-released/index.html
+++ b/2013/04/29/proprietary-amdati-fglrx-12-104-catalyst-13-4-rpm-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/04/index.html
+++ b/2013/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/05/08/announcing-the-release-of-opensuse-edu-li-f-e-12-3-1/index.html
+++ b/2013/05/08/announcing-the-release-of-opensuse-edu-li-f-e-12-3-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/05/08/index.html
+++ b/2013/05/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/05/09/index.html
+++ b/2013/05/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/05/09/opensuse-12-3-on-android/index.html
+++ b/2013/05/09/opensuse-12-3-on-android/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/05/10/index.html
+++ b/2013/05/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/05/10/opensuse-multimedia-based-on-opensuse-12-3-2/index.html
+++ b/2013/05/10/opensuse-multimedia-based-on-opensuse-12-3-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/05/30/index.html
+++ b/2013/05/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/05/30/presenting-the-opensuse-team-blog/index.html
+++ b/2013/05/30/presenting-the-opensuse-team-blog/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/05/index.html
+++ b/2013/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/02/bareos-an-interesting-replacement-to-bacula/index.html
+++ b/2013/06/02/bareos-an-interesting-replacement-to-bacula/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/02/index.html
+++ b/2013/06/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/06/index.html
+++ b/2013/06/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/06/openqa-in-opensuse/index.html
+++ b/2013/06/06/openqa-in-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/13/index.html
+++ b/2013/06/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/13/keeping-factory-in-shape/index.html
+++ b/2013/06/13/keeping-factory-in-shape/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/16/i-will-miss-the-5th-edition-of-opensuse-conference/index.html
+++ b/2013/06/16/i-will-miss-the-5th-edition-of-opensuse-conference/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/16/index.html
+++ b/2013/06/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/18/index.html
+++ b/2013/06/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/18/the-resourcefulness-of-our-great-community-an-example/index.html
+++ b/2013/06/18/the-resourcefulness-of-our-great-community-an-example/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/20/index.html
+++ b/2013/06/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/20/the-opensuse-tsp-application/index.html
+++ b/2013/06/20/the-opensuse-tsp-application/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/27/index.html
+++ b/2013/06/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/27/the-opensuse-team-at-osc13/index.html
+++ b/2013/06/27/the-opensuse-team-at-osc13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/06/index.html
+++ b/2013/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/07/04/index.html
+++ b/2013/07/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/07/04/numbers-is-opensuse/index.html
+++ b/2013/07/04/numbers-is-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/07/11/index.html
+++ b/2013/07/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/07/11/merchandising/index.html
+++ b/2013/07/11/merchandising/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/07/22/index.html
+++ b/2013/07/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/07/22/some-post-processing-of-osc13/index.html
+++ b/2013/07/22/some-post-processing-of-osc13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/07/index.html
+++ b/2013/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/02/index.html
+++ b/2013/08/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/02/opensuse-conference-is-over/index.html
+++ b/2013/08/02/opensuse-conference-is-over/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/09/happy-birthday-opensuse/index.html
+++ b/2013/08/09/happy-birthday-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/09/index.html
+++ b/2013/08/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/13/index.html
+++ b/2013/08/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/13/osc13-some-more-details-and-thoughts/index.html
+++ b/2013/08/13/osc13-some-more-details-and-thoughts/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/15/coordinating-work/index.html
+++ b/2013/08/15/coordinating-work/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/15/index.html
+++ b/2013/08/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/15/proprietary-amdati-catalyst-fglrx-13-8-beta1-13-20-5-1-rpm-released/index.html
+++ b/2013/08/15/proprietary-amdati-catalyst-fglrx-13-8-beta1-13-20-5-1-rpm-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/23/index.html
+++ b/2013/08/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/23/more-on-statistics/index.html
+++ b/2013/08/23/more-on-statistics/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/29/index.html
+++ b/2013/08/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/29/the-opensuse-release-process/index.html
+++ b/2013/08/29/the-opensuse-release-process/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/08/index.html
+++ b/2013/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/05/index.html
+++ b/2013/09/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/05/obs-webui-gets-new-search-functionality/index.html
+++ b/2013/09/05/obs-webui-gets-new-search-functionality/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/07/index.html
+++ b/2013/09/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/07/new-raspberry-pi-image/index.html
+++ b/2013/09/07/new-raspberry-pi-image/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/13/index.html
+++ b/2013/09/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/13/magic-it-is-now-possible-to-use-ms-silverlight-based-website-via-pipelight/index.html
+++ b/2013/09/13/magic-it-is-now-possible-to-use-ms-silverlight-based-website-via-pipelight/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/18/documenting-the-opensuse-development-and-release-process/index.html
+++ b/2013/09/18/documenting-the-opensuse-development-and-release-process/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/18/index.html
+++ b/2013/09/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/22/how-i-ran-opensuse-on-a-nexus-7/index.html
+++ b/2013/09/22/how-i-ran-opensuse-on-a-nexus-7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/22/index.html
+++ b/2013/09/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/25/index.html
+++ b/2013/09/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/25/merchandising-where-we-are-going/index.html
+++ b/2013/09/25/merchandising-where-we-are-going/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/09/index.html
+++ b/2013/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/01/index.html
+++ b/2013/10/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/01/use-the-scan-to-pc-function-on-a-samsung-multifunction/index.html
+++ b/2013/10/01/use-the-scan-to-pc-function-on-a-samsung-multifunction/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/02/creating-openqa-test-cases-for-opensuse-13-1/index.html
+++ b/2013/10/02/creating-openqa-test-cases-for-opensuse-13-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/02/index.html
+++ b/2013/10/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/06/index.html
+++ b/2013/10/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/06/only-for-the-brave-proprietary-amdati-catalyst-fglrx-13-10-beta2-13-20-11-1-rpm-released/index.html
+++ b/2013/10/06/only-for-the-brave-proprietary-amdati-catalyst-fglrx-13-10-beta2-13-20-11-1-rpm-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/07/index.html
+++ b/2013/10/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/07/opensuse-and-gcc-part1/index.html
+++ b/2013/10/07/opensuse-and-gcc-part1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/08/hackweek-hot-chili-sauce-for-hot-lizards/index.html
+++ b/2013/10/08/hackweek-hot-chili-sauce-for-hot-lizards/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/08/index.html
+++ b/2013/10/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/15/index.html
+++ b/2013/10/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/15/opensuse-and-gcc-part-2/index.html
+++ b/2013/10/15/opensuse-and-gcc-part-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/17/beta-and-rc-work/index.html
+++ b/2013/10/17/beta-and-rc-work/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/17/index.html
+++ b/2013/10/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/22/index.html
+++ b/2013/10/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/22/opensuse-and-gcc-part-3/index.html
+++ b/2013/10/22/opensuse-and-gcc-part-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/24/index.html
+++ b/2013/10/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/24/linuxdays-2013/index.html
+++ b/2013/10/24/linuxdays-2013/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/28/index.html
+++ b/2013/10/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/28/opensuse-and-gcc-part4/index.html
+++ b/2013/10/28/opensuse-and-gcc-part4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/10/index.html
+++ b/2013/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/05/index.html
+++ b/2013/11/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/05/opensuse-and-gcc-part-5/index.html
+++ b/2013/11/05/opensuse-and-gcc-part-5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/12/amd-flgrx-status/index.html
+++ b/2013/11/12/amd-flgrx-status/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/12/index.html
+++ b/2013/11/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/12/opensuse-and-gcc-part-6/index.html
+++ b/2013/11/12/opensuse-and-gcc-part-6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/13/hongkong-openstack-design-summit/index.html
+++ b/2013/11/13/hongkong-openstack-design-summit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/13/index.html
+++ b/2013/11/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/19/index.html
+++ b/2013/11/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/19/opensuse-and-gcc-part-7/index.html
+++ b/2013/11/19/opensuse-and-gcc-part-7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/20/index.html
+++ b/2013/11/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/20/proprietary-amdati-catalyst-fglrx-13-11-beta6-13-25-18-1-rpm-are-released-for-any-opensuse-version/index.html
+++ b/2013/11/20/proprietary-amdati-catalyst-fglrx-13-11-beta6-13-25-18-1-rpm-are-released-for-any-opensuse-version/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/22/index.html
+++ b/2013/11/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/22/working-on-an-opensuse-release/index.html
+++ b/2013/11/22/working-on-an-opensuse-release/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/23/index.html
+++ b/2013/11/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/23/yippee-yeah-another-proprietary-amdati-catalyst-fglrx-13-11-beta-v9-4-13-25-18-2-rpm-are-released-for-any-opensuse-version/index.html
+++ b/2013/11/23/yippee-yeah-another-proprietary-amdati-catalyst-fglrx-13-11-beta-v9-4-13-25-18-2-rpm-are-released-for-any-opensuse-version/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/26/index.html
+++ b/2013/11/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/26/we-are-the-robots/index.html
+++ b/2013/11/26/we-are-the-robots/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/28/amd-fglrx-ymp-one-click-install-and-stable-repository/index.html
+++ b/2013/11/28/amd-fglrx-ymp-one-click-install-and-stable-repository/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/28/index.html
+++ b/2013/11/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/11/index.html
+++ b/2013/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/03/index.html
+++ b/2013/12/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/03/opensuse-and-gcc-part-8-rpms-and-how-to-write-them/index.html
+++ b/2013/12/03/opensuse-and-gcc-part-8-rpms-and-how-to-write-them/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/11/discussing-about-the-future-of-opensuse/index.html
+++ b/2013/12/11/discussing-about-the-future-of-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/11/index.html
+++ b/2013/12/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/11/opensuse-and-gcc-part-9/index.html
+++ b/2013/12/11/opensuse-and-gcc-part-9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/16/continuing-opening-yast/index.html
+++ b/2013/12/16/continuing-opening-yast/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/16/index.html
+++ b/2013/12/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/16/waouh-thank-you-merci-danke-etc/index.html
+++ b/2013/12/16/waouh-thank-you-merci-danke-etc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/17/announcing-opensuse-education-li-f-e-13-1/index.html
+++ b/2013/12/17/announcing-opensuse-education-li-f-e-13-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/17/index.html
+++ b/2013/12/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/19/enter-unreal-world-rpg/index.html
+++ b/2013/12/19/enter-unreal-world-rpg/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/19/index.html
+++ b/2013/12/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/21/index.html
+++ b/2013/12/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/21/owners-of-fglrx-card-using-opensuse-12-1-cleanup-your-repositories/index.html
+++ b/2013/12/21/owners-of-fglrx-card-using-opensuse-12-1-cleanup-your-repositories/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/21/proprietary-amdati-fglrx-13-251-1-catalyst-13-12-rpm-finally-released/index.html
+++ b/2013/12/21/proprietary-amdati-fglrx-13-251-1-catalyst-13-12-rpm-finally-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/12/index.html
+++ b/2013/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/index.html
+++ b/2013/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/page/2/index.html
+++ b/2013/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/page/3/index.html
+++ b/2013/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/page/4/index.html
+++ b/2013/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/page/5/index.html
+++ b/2013/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/page/6/index.html
+++ b/2013/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/page/7/index.html
+++ b/2013/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2013/page/8/index.html
+++ b/2013/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/07/index.html
+++ b/2014/01/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/07/opensuse-and-gcc-part-10/index.html
+++ b/2014/01/07/opensuse-and-gcc-part-10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/12/index.html
+++ b/2014/01/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/12/mounting-truecrypt-volumes-in-gnulinux-using-cryptsetup/index.html
+++ b/2014/01/12/mounting-truecrypt-volumes-in-gnulinux-using-cryptsetup/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/15/index.html
+++ b/2014/01/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/15/unterstanding-the-nvidia-driver-process/index.html
+++ b/2014/01/15/unterstanding-the-nvidia-driver-process/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/17/index.html
+++ b/2014/01/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/17/no-forgotten-patch-to-yast-anymore/index.html
+++ b/2014/01/17/no-forgotten-patch-to-yast-anymore/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/21/index.html
+++ b/2014/01/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/21/opensuse-education-li-f-e-13-1-x86_64-with-uefi-boot-support/index.html
+++ b/2014/01/21/opensuse-education-li-f-e-13-1-x86_64-with-uefi-boot-support/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/24/how-to-destroy-your-data-from-harddisk-permamently/index.html
+++ b/2014/01/24/how-to-destroy-your-data-from-harddisk-permamently/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/24/index.html
+++ b/2014/01/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/27/beta-proprietary-amdati-fglrx-13-11-betav9-95-catalyst-13-25-18-3-rpm-released/index.html
+++ b/2014/01/27/beta-proprietary-amdati-fglrx-13-11-betav9-95-catalyst-13-25-18-3-rpm-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/27/index.html
+++ b/2014/01/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/27/proprietary-amdati-catalyst-fglrx-13-12-13-251-3-rpm-get-a-new-build-release/index.html
+++ b/2014/01/27/proprietary-amdati-catalyst-fglrx-13-12-13-251-3-rpm-get-a-new-build-release/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/29/index.html
+++ b/2014/01/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/29/network-boot-live-iso/index.html
+++ b/2014/01/29/network-boot-live-iso/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/31/index.html
+++ b/2014/01/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/31/spec-cleaner-hide-all-your-precious-cruft/index.html
+++ b/2014/01/31/spec-cleaner-hide-all-your-precious-cruft/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/01/index.html
+++ b/2014/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/03/index.html
+++ b/2014/02/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/03/trying-to-add-some-light/index.html
+++ b/2014/02/03/trying-to-add-some-light/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/04/fosdem-2014-report-beta-testing-new-opensuse-booth-merchandising-stuff/index.html
+++ b/2014/02/04/fosdem-2014-report-beta-testing-new-opensuse-booth-merchandising-stuff/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/04/index.html
+++ b/2014/02/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/07/index.html
+++ b/2014/02/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/07/some-news-from-the-trenches/index.html
+++ b/2014/02/07/some-news-from-the-trenches/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/08/another-way-to-access-a-cloud-vms-vnc-console/index.html
+++ b/2014/02/08/another-way-to-access-a-cloud-vms-vnc-console/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/08/index.html
+++ b/2014/02/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/13/elfcloud-fi-a-small-cloud-storage-that-could/index.html
+++ b/2014/02/13/elfcloud-fi-a-small-cloud-storage-that-could/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/13/index.html
+++ b/2014/02/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/19/code-quality-and-code-guidelines/index.html
+++ b/2014/02/19/code-quality-and-code-guidelines/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/19/first-fruits-update-on-openqa-and-staging-work/index.html
+++ b/2014/02/19/first-fruits-update-on-openqa-and-staging-work/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/19/index.html
+++ b/2014/02/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/26/goodbye-ec2-tools-long-live-aws-tools/index.html
+++ b/2014/02/26/goodbye-ec2-tools-long-live-aws-tools/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/26/index.html
+++ b/2014/02/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/28/about-openqa-and-authentication/index.html
+++ b/2014/02/28/about-openqa-and-authentication/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/28/index.html
+++ b/2014/02/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/02/index.html
+++ b/2014/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/06/getting-my-dvb-t-card-to-work/index.html
+++ b/2014/03/06/getting-my-dvb-t-card-to-work/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/06/index.html
+++ b/2014/03/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/06/short-report-from-installfest-2014-prague/index.html
+++ b/2014/03/06/short-report-from-installfest-2014-prague/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/10/index.html
+++ b/2014/03/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/10/is-my-server-alive-and-how-good-is-my-connection/index.html
+++ b/2014/03/10/is-my-server-alive-and-how-good-is-my-connection/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/13/help-yourselves-to-our-low-hanging-fruit/index.html
+++ b/2014/03/13/help-yourselves-to-our-low-hanging-fruit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/13/index.html
+++ b/2014/03/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/15/index.html
+++ b/2014/03/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/15/osc-build-with-kvm-on-an-encrypted-volume-group/index.html
+++ b/2014/03/15/osc-build-with-kvm-on-an-encrypted-volume-group/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/19/cloudy-with-a-touch-of-green/index.html
+++ b/2014/03/19/cloudy-with-a-touch-of-green/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/19/how-to-filter-a-certain-class-of-hardware-in-dhcpd-conf/index.html
+++ b/2014/03/19/how-to-filter-a-certain-class-of-hardware-in-dhcpd-conf/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/19/index.html
+++ b/2014/03/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/23/index.html
+++ b/2014/03/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/23/proprietary-amdati-catalyst-fglrx-rpms-released/index.html
+++ b/2014/03/23/proprietary-amdati-catalyst-fglrx-rpms-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/24/emscripten-and-opensuse-hands-on-hands-up/index.html
+++ b/2014/03/24/emscripten-and-opensuse-hands-on-hands-up/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/24/index.html
+++ b/2014/03/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/03/index.html
+++ b/2014/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/04/15/have-some-fun-today-compile-kernel/index.html
+++ b/2014/04/15/have-some-fun-today-compile-kernel/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/04/15/index.html
+++ b/2014/04/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/04/30/have-some-fun-today-try-your-new-kernel/index.html
+++ b/2014/04/30/have-some-fun-today-try-your-new-kernel/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/04/30/index.html
+++ b/2014/04/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/04/index.html
+++ b/2014/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/02/index.html
+++ b/2014/05/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/02/proprietary-amdati-catalyst-fglrx-14-4-14-10-1006-1-rpm-released/index.html
+++ b/2014/05/02/proprietary-amdati-catalyst-fglrx-14-4-14-10-1006-1-rpm-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/08/echoes-from-osc14-state-of-factory-and-openqa/index.html
+++ b/2014/05/08/echoes-from-osc14-state-of-factory-and-openqa/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/08/index.html
+++ b/2014/05/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/11/a-brief-report-on-osc-14/index.html
+++ b/2014/05/11/a-brief-report-on-osc-14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/11/index.html
+++ b/2014/05/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/12/index.html
+++ b/2014/05/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/12/web-frontend-to-change-ldap-password/index.html
+++ b/2014/05/12/web-frontend-to-change-ldap-password/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/15/index.html
+++ b/2014/05/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/15/lxqt-is-ready-for-testing/index.html
+++ b/2014/05/15/lxqt-is-ready-for-testing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/19/index.html
+++ b/2014/05/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/19/opensuse-edu-li-f-e-mate/index.html
+++ b/2014/05/19/opensuse-edu-li-f-e-mate/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/23/gnome-classic-edition-of-opensuse-education/index.html
+++ b/2014/05/23/gnome-classic-edition-of-opensuse-education/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/23/index.html
+++ b/2014/05/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/28/have-some-fun-patch-your-kernel/index.html
+++ b/2014/05/28/have-some-fun-patch-your-kernel/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/28/index.html
+++ b/2014/05/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/31/index.html
+++ b/2014/05/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/31/tiny-core-kiwi-ltsp-thin-client/index.html
+++ b/2014/05/31/tiny-core-kiwi-ltsp-thin-client/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/05/index.html
+++ b/2014/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/01/disable-firefox-addon-compatibility-check-after-update/index.html
+++ b/2014/06/01/disable-firefox-addon-compatibility-check-after-update/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/01/index.html
+++ b/2014/06/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/12/and-done-new-images-available/index.html
+++ b/2014/06/12/and-done-new-images-available/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/12/factory-restore-system-rescue/index.html
+++ b/2014/06/12/factory-restore-system-rescue/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/12/index.html
+++ b/2014/06/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/13/index.html
+++ b/2014/06/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/13/opensuse-13-2-artwork-proposal/index.html
+++ b/2014/06/13/opensuse-13-2-artwork-proposal/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/16/gnome-3-12-classic-on-opensuse-13-1/index.html
+++ b/2014/06/16/gnome-3-12-classic-on-opensuse-13-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/16/index.html
+++ b/2014/06/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/16/using-docker-1-0-on-opensuse-13-1/index.html
+++ b/2014/06/16/using-docker-1-0-on-opensuse-13-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/26/index.html
+++ b/2014/06/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/26/osc-speedup-update-of-a-project-working-copy/index.html
+++ b/2014/06/26/osc-speedup-update-of-a-project-working-copy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/06/index.html
+++ b/2014/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/07/01/10906/index.html
+++ b/2014/07/01/10906/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/07/01/index.html
+++ b/2014/07/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/07/02/index.html
+++ b/2014/07/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/07/02/javascript-tools-in-opensuse-round-1-jshint/index.html
+++ b/2014/07/02/javascript-tools-in-opensuse-round-1-jshint/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/07/06/fosdem-2015-31st-january-1st-february-brussel-call/index.html
+++ b/2014/07/06/fosdem-2015-31st-january-1st-february-brussel-call/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/07/06/index.html
+++ b/2014/07/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/07/20/index.html
+++ b/2014/07/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/07/20/updated-opensuse-edu-li-f-e-gnome-classic/index.html
+++ b/2014/07/20/updated-opensuse-edu-li-f-e-gnome-classic/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/07/23/index.html
+++ b/2014/07/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/07/23/openstack-infraqa-meetup/index.html
+++ b/2014/07/23/openstack-infraqa-meetup/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/07/index.html
+++ b/2014/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/08/03/fosdem-proposals-for-main-track-presentations-and-developer-rooms/index.html
+++ b/2014/08/03/fosdem-proposals-for-main-track-presentations-and-developer-rooms/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/08/03/index.html
+++ b/2014/08/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/08/17/beta-proprietary-amdati-catalyst-fglrx-14-20-beta-v1-0-july-11-2014-rpm-are-released-for-several-opensuse-version/index.html
+++ b/2014/08/17/beta-proprietary-amdati-catalyst-fglrx-14-20-beta-v1-0-july-11-2014-rpm-are-released-for-several-opensuse-version/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/08/17/index.html
+++ b/2014/08/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/08/18/index.html
+++ b/2014/08/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/08/18/javascript-tools-in-opensuse-round-2-js-beautify/index.html
+++ b/2014/08/18/javascript-tools-in-opensuse-round-2-js-beautify/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/08/25/index.html
+++ b/2014/08/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/08/25/lsb-best-effort/index.html
+++ b/2014/08/25/lsb-best-effort/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/08/25/randa-meetings-august-2014-report-from-a-geekos-point-of-view/index.html
+++ b/2014/08/25/randa-meetings-august-2014-report-from-a-geekos-point-of-view/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/08/index.html
+++ b/2014/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/09/12/birdfont-fonteditor/index.html
+++ b/2014/09/12/birdfont-fonteditor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/09/12/index.html
+++ b/2014/09/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/09/14/index.html
+++ b/2014/09/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/09/14/running-an-opensuse-booth-at-kde-akademy-2014/index.html
+++ b/2014/09/14/running-an-opensuse-booth-at-kde-akademy-2014/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/09/19/index.html
+++ b/2014/09/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/09/19/opensuse-booth-at-akademy-now-with-a-video/index.html
+++ b/2014/09/19/opensuse-booth-at-akademy-now-with-a-video/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/09/index.html
+++ b/2014/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/10/08/index.html
+++ b/2014/10/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/10/08/ruby-do-not-use-in-loops/index.html
+++ b/2014/10/08/ruby-do-not-use-in-loops/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/10/11/index.html
+++ b/2014/10/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/10/11/proprietary-amdati-catalyst-fglrx-14-9-14-301-1001-1-rpm-released/index.html
+++ b/2014/10/11/proprietary-amdati-catalyst-fglrx-14-9-14-301-1001-1-rpm-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/10/14/index.html
+++ b/2014/10/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/10/14/opensuse-asia-summit-18-19-october/index.html
+++ b/2014/10/14/opensuse-asia-summit-18-19-october/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/10/24/index.html
+++ b/2014/10/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/10/24/unreal-world-rpg-and-propiertary-applications-in-linux-ecosystem/index.html
+++ b/2014/10/24/unreal-world-rpg-and-propiertary-applications-in-linux-ecosystem/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/10/31/back-from-opensuse-asia-summit-2014/index.html
+++ b/2014/10/31/back-from-opensuse-asia-summit-2014/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/10/31/index.html
+++ b/2014/10/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/10/index.html
+++ b/2014/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/11/01/fglrx-warning-opensuse-13-2-tumbleweed/index.html
+++ b/2014/11/01/fglrx-warning-opensuse-13-2-tumbleweed/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/11/01/index.html
+++ b/2014/11/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/11/13/amd-fglrx-the-14-9-refurbished-version-for-opensuse-13-2-and-tumbleweed/index.html
+++ b/2014/11/13/amd-fglrx-the-14-9-refurbished-version-for-opensuse-13-2-and-tumbleweed/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/11/13/index.html
+++ b/2014/11/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/11/14/index.html
+++ b/2014/11/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/11/14/unreal-world-rpg-and-propiertary-applications-in-linux-ecosystem-part-sdl2/index.html
+++ b/2014/11/14/unreal-world-rpg-and-propiertary-applications-in-linux-ecosystem-part-sdl2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/11/index.html
+++ b/2014/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/12/06/index.html
+++ b/2014/12/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/12/06/opensuse-education-li-f-e-13-2-1-out-now/index.html
+++ b/2014/12/06/opensuse-education-li-f-e-13-2-1-out-now/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/12/13/index.html
+++ b/2014/12/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/12/13/new-proprietary-amdati-catalyst-omega-fglrx-14-12-14-501-1003-1-rpm-released/index.html
+++ b/2014/12/13/new-proprietary-amdati-catalyst-omega-fglrx-14-12-14-501-1003-1-rpm-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/12/16/index.html
+++ b/2014/12/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/12/16/its-hoolihoolihooliday-and-what-fun-i-can-do/index.html
+++ b/2014/12/16/its-hoolihoolihooliday-and-what-fun-i-can-do/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/12/16/ltsp-client-goes-banana-pi/index.html
+++ b/2014/12/16/ltsp-client-goes-banana-pi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/12/27/index.html
+++ b/2014/12/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/12/27/standing-for-re-election-opensuse-board-election-jan-2015/index.html
+++ b/2014/12/27/standing-for-re-election-opensuse-board-election-jan-2015/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/12/index.html
+++ b/2014/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/index.html
+++ b/2014/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/page/2/index.html
+++ b/2014/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/page/3/index.html
+++ b/2014/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/page/4/index.html
+++ b/2014/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/page/5/index.html
+++ b/2014/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/page/6/index.html
+++ b/2014/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/page/7/index.html
+++ b/2014/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2014/page/8/index.html
+++ b/2014/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/06/index.html
+++ b/2015/01/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/06/testing-android-in-openqa/index.html
+++ b/2015/01/06/testing-android-in-openqa/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -563,7 +558,6 @@ To find out I <a href="http://www.suse.de/~lnussel/setupgrubfornfsinstall.html">
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/comment-reply.min.js?ver=4.7.5'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/2015/01/08/ganglia-opensuse-board-campaign/index.html
+++ b/2015/01/08/ganglia-opensuse-board-campaign/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/08/index.html
+++ b/2015/01/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/12/index.html
+++ b/2015/01/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/12/standing-for-re-election-to-the-opensuse-board/index.html
+++ b/2015/01/12/standing-for-re-election-to-the-opensuse-board/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/16/index.html
+++ b/2015/01/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/16/linux-audio-library-smackdown-part1-portaudio/index.html
+++ b/2015/01/16/linux-audio-library-smackdown-part1-portaudio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/17/index.html
+++ b/2015/01/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/17/osc15-200-why-not-packaging-workshop-like-mini-hack-sprint/index.html
+++ b/2015/01/17/osc15-200-why-not-packaging-workshop-like-mini-hack-sprint/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/22/final-election-thoughts/index.html
+++ b/2015/01/22/final-election-thoughts/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/22/index.html
+++ b/2015/01/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/27/index.html
+++ b/2015/01/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/27/linux-audio-library-smackdown-part2-pulseaudio/index.html
+++ b/2015/01/27/linux-audio-library-smackdown-part2-pulseaudio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/01/index.html
+++ b/2015/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/02/05/index.html
+++ b/2015/02/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/02/05/linux-audio-library-smackdown-part3-sdl/index.html
+++ b/2015/02/05/linux-audio-library-smackdown-part3-sdl/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/02/06/index.html
+++ b/2015/02/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/02/06/ssd-configuration-for-opensuse/index.html
+++ b/2015/02/06/ssd-configuration-for-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/02/17/fonts-opensuse/index.html
+++ b/2015/02/17/fonts-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/02/17/index.html
+++ b/2015/02/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/02/17/lizards-time-to-pack-your-stuff-for-opensuse-minisummit-scale-13x/index.html
+++ b/2015/02/17/lizards-time-to-pack-your-stuff-for-opensuse-minisummit-scale-13x/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/02/20/index.html
+++ b/2015/02/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/02/20/opensuse-minisummit-scale13x-summary/index.html
+++ b/2015/02/20/opensuse-minisummit-scale13x-summary/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/02/27/amd-fglrx-new-rebuild-14-501-1003-2-supporting-kernel-3-19-for-opensuse-13-1-13-2-and-tumbleweed/index.html
+++ b/2015/02/27/amd-fglrx-new-rebuild-14-501-1003-2-supporting-kernel-3-19-for-opensuse-13-1-13-2-and-tumbleweed/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/02/27/index.html
+++ b/2015/02/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/02/index.html
+++ b/2015/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/03/02/index.html
+++ b/2015/03/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/03/02/linux-audio-library-smackdown-part4-libao/index.html
+++ b/2015/03/02/linux-audio-library-smackdown-part4-libao/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/03/26/compile-znc-irc-bouncer-on-raspberry-pi/index.html
+++ b/2015/03/26/compile-znc-irc-bouncer-on-raspberry-pi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/03/26/how-to-organize-a-release-party-for-a-project/index.html
+++ b/2015/03/26/how-to-organize-a-release-party-for-a-project/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/03/26/how-to-organize-start-an-open-source-community/index.html
+++ b/2015/03/26/how-to-organize-start-an-open-source-community/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/03/26/how-to-organize-your-trip-your-projects-presence-to-a-conference/index.html
+++ b/2015/03/26/how-to-organize-your-trip-your-projects-presence-to-a-conference/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/03/26/index.html
+++ b/2015/03/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/03/26/vamox-icons/index.html
+++ b/2015/03/26/vamox-icons/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/03/index.html
+++ b/2015/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/01/index.html
+++ b/2015/04/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/01/unreal-world-rpg-and-propiertary-applications-in-linux-ecosystem-part-sdl2-take-2/index.html
+++ b/2015/04/01/unreal-world-rpg-and-propiertary-applications-in-linux-ecosystem-part-sdl2-take-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/08/amd-catalyst-15-3-beta-for-opensuse-new-makerpm-amd-script-is-available/index.html
+++ b/2015/04/08/amd-catalyst-15-3-beta-for-opensuse-new-makerpm-amd-script-is-available/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/08/index.html
+++ b/2015/04/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/11/how-to-promote-your-conference/index.html
+++ b/2015/04/11/how-to-promote-your-conference/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/11/index.html
+++ b/2015/04/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/20/index.html
+++ b/2015/04/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/20/using-opensuse-as-a-reverse-tunnel-site-for-windows-7-remote-desktop/index.html
+++ b/2015/04/20/using-opensuse-as-a-reverse-tunnel-site-for-windows-7-remote-desktop/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/26/index.html
+++ b/2015/04/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/26/zypper-tab-completion-and-some-thoughts/index.html
+++ b/2015/04/26/zypper-tab-completion-and-some-thoughts/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/29/ever-wanted-to-be-a-dj-with-open-source-touch/index.html
+++ b/2015/04/29/ever-wanted-to-be-a-dj-with-open-source-touch/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/29/index.html
+++ b/2015/04/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/29/yast-fonts-got-user-mode/index.html
+++ b/2015/04/29/yast-fonts-got-user-mode/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/04/index.html
+++ b/2015/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/06/developing-developers/index.html
+++ b/2015/05/06/developing-developers/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/06/index.html
+++ b/2015/05/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/10/how-to-get-superbly-hinted-fonts-in-opensuse-13-2/index.html
+++ b/2015/05/10/how-to-get-superbly-hinted-fonts-in-opensuse-13-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/10/index.html
+++ b/2015/05/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/18/create-an-sd-card-for-your-raspberry-pi-b-and-b/index.html
+++ b/2015/05/18/create-an-sd-card-for-your-raspberry-pi-b-and-b/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/18/index.html
+++ b/2015/05/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/19/index.html
+++ b/2015/05/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/19/no-ip-and-opensuse-raspberry-pi/index.html
+++ b/2015/05/19/no-ip-and-opensuse-raspberry-pi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/20/inadyn-and-opensuse-raspberry-pi/index.html
+++ b/2015/05/20/inadyn-and-opensuse-raspberry-pi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/20/index.html
+++ b/2015/05/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/21/index.html
+++ b/2015/05/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/21/set-static-ip-on-your-opensuse-raspberry-pi/index.html
+++ b/2015/05/21/set-static-ip-on-your-opensuse-raspberry-pi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/22/index.html
+++ b/2015/05/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/22/make-your-opensuse-raspberry-pi-a-seedbox/index.html
+++ b/2015/05/22/make-your-opensuse-raspberry-pi-a-seedbox/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/23/index.html
+++ b/2015/05/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/23/run-copy-com-on-your-opensuse-raspberry-pi/index.html
+++ b/2015/05/23/run-copy-com-on-your-opensuse-raspberry-pi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/24/index.html
+++ b/2015/05/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/24/upgrade-your-opensuse-raspberry-pi-from-13-1-to-13-2/index.html
+++ b/2015/05/24/upgrade-your-opensuse-raspberry-pi-from-13-1-to-13-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/25/index.html
+++ b/2015/05/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/25/install-ddclient-on-your-opensuse-raspberry-pi/index.html
+++ b/2015/05/25/install-ddclient-on-your-opensuse-raspberry-pi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/27/index.html
+++ b/2015/05/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/27/opensuse-on-gnome-asia-2015/index.html
+++ b/2015/05/27/opensuse-on-gnome-asia-2015/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/30/create-multi-liveusb-with-opensuse/index.html
+++ b/2015/05/30/create-multi-liveusb-with-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/30/index.html
+++ b/2015/05/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/index.html
+++ b/2015/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/05/page/2/index.html
+++ b/2015/05/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/06/06/index.html
+++ b/2015/06/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/06/06/zypper-install-tab-completion/index.html
+++ b/2015/06/06/zypper-install-tab-completion/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/06/15/amd-catalyst-15-5-for-opensuse-new-makerpm-amd-script-is-available/index.html
+++ b/2015/06/15/amd-catalyst-15-5-for-opensuse-new-makerpm-amd-script-is-available/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/06/15/index.html
+++ b/2015/06/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/06/23/daps-2-0-released/index.html
+++ b/2015/06/23/daps-2-0-released/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/06/23/index.html
+++ b/2015/06/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/06/index.html
+++ b/2015/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/07/08/digital-game-distribution/index.html
+++ b/2015/07/08/digital-game-distribution/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/07/08/index.html
+++ b/2015/07/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/07/12/amd-catalyst-15-7-for-opensuse-new-makerpm-amd-script-is-available/index.html
+++ b/2015/07/12/amd-catalyst-15-7-for-opensuse-new-makerpm-amd-script-is-available/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/07/12/index.html
+++ b/2015/07/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/07/index.html
+++ b/2015/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/08/18/index.html
+++ b/2015/08/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/08/18/oh-hell-its-open-source-project/index.html
+++ b/2015/08/18/oh-hell-its-open-source-project/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/08/28/index.html
+++ b/2015/08/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/08/28/this-my-code-take-it-contributing-to-open-source-project/index.html
+++ b/2015/08/28/this-my-code-take-it-contributing-to-open-source-project/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/08/index.html
+++ b/2015/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/09/17/how-to-create-an-opensuse-banana-pi-m1-image-with-mate-desktop/index.html
+++ b/2015/09/17/how-to-create-an-opensuse-banana-pi-m1-image-with-mate-desktop/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/09/17/index.html
+++ b/2015/09/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/09/27/amd-catalyst-15-9-for-opensuse-new-makerpm-amd-script-is-available/index.html
+++ b/2015/09/27/amd-catalyst-15-9-for-opensuse-new-makerpm-amd-script-is-available/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/09/27/index.html
+++ b/2015/09/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/09/index.html
+++ b/2015/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/10/05/index.html
+++ b/2015/10/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/10/05/targitter-project-about-obs-tars-and-git/index.html
+++ b/2015/10/05/targitter-project-about-obs-tars-and-git/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/10/25/cleanup-on-obs-bacula-packages-to-adopt/index.html
+++ b/2015/10/25/cleanup-on-obs-bacula-packages-to-adopt/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/10/25/index.html
+++ b/2015/10/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/10/31/index.html
+++ b/2015/10/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/10/31/proprietary-amdati-catalyst-fglrx-rpms-released-for-leap-42-1/index.html
+++ b/2015/10/31/proprietary-amdati-catalyst-fglrx-rpms-released-for-leap-42-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/10/index.html
+++ b/2015/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/11/12/fosscomm-2015-athens-nov-6-8/index.html
+++ b/2015/11/12/fosscomm-2015-athens-nov-6-8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/11/12/index.html
+++ b/2015/11/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/11/27/hi-how-are-you-doing-sorry-you-cant-get-through-just-leave-your-name-and-you-number-and-ill-get-back-to-you/index.html
+++ b/2015/11/27/hi-how-are-you-doing-sorry-you-cant-get-through-just-leave-your-name-and-you-number-and-ill-get-back-to-you/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/11/27/index.html
+++ b/2015/11/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/11/index.html
+++ b/2015/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/03/banana-pi-m2-running-opensuse-tumbleweed/index.html
+++ b/2015/12/03/banana-pi-m2-running-opensuse-tumbleweed/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/03/index.html
+++ b/2015/12/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/05/amd-catalyst-15-11-for-opensuse-new-makerpm-amd-script-is-available/index.html
+++ b/2015/12/05/amd-catalyst-15-11-for-opensuse-new-makerpm-amd-script-is-available/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/05/index.html
+++ b/2015/12/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/06/index.html
+++ b/2015/12/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/06/proprietary-amdati-catalyst-fglrx-rpms-new-release-15-11-15-300-1025-1/index.html
+++ b/2015/12/06/proprietary-amdati-catalyst-fglrx-rpms-new-release-15-11-15-300-1025-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/15/index.html
+++ b/2015/12/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/15/lets-blog-about-yast/index.html
+++ b/2015/12/15/lets-blog-about-yast/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/21/announcing-li-f-e-42-1/index.html
+++ b/2015/12/21/announcing-li-f-e-42-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/21/announcing-li-f-e-42-1/screenshot-from-2015-12-20-16-41-37/index.html
+++ b/2015/12/21/announcing-li-f-e-42-1/screenshot-from-2015-12-20-16-41-37/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Mate desktop" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/21/announcing-li-f-e-42-1/snapshot10/index.html
+++ b/2015/12/21/announcing-li-f-e-42-1/snapshot10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Graphics" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/21/announcing-li-f-e-42-1/snapshot11/index.html
+++ b/2015/12/21/announcing-li-f-e-42-1/snapshot11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Office" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/21/announcing-li-f-e-42-1/snapshot12/index.html
+++ b/2015/12/21/announcing-li-f-e-42-1/snapshot12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Multimedia" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/21/announcing-li-f-e-42-1/snapshot15/index.html
+++ b/2015/12/21/announcing-li-f-e-42-1/snapshot15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Learning" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/21/announcing-li-f-e-42-1/snapshot16/index.html
+++ b/2015/12/21/announcing-li-f-e-42-1/snapshot16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Learning" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/21/announcing-li-f-e-42-1/snapshot7/index.html
+++ b/2015/12/21/announcing-li-f-e-42-1/snapshot7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Games" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/21/announcing-li-f-e-42-1/snapshot8/index.html
+++ b/2015/12/21/announcing-li-f-e-42-1/snapshot8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Development" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/21/index.html
+++ b/2015/12/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/25/index.html
+++ b/2015/12/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/25/live-iso-multi-boot-usb-revisited-live-grub-stick/index.html
+++ b/2015/12/25/live-iso-multi-boot-usb-revisited-live-grub-stick/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/12/index.html
+++ b/2015/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/index.html
+++ b/2015/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/page/2/index.html
+++ b/2015/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/page/3/index.html
+++ b/2015/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/page/4/index.html
+++ b/2015/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/page/5/index.html
+++ b/2015/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2015/page/6/index.html
+++ b/2015/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/01/07/highlights-of-development-sprint-13/index.html
+++ b/2016/01/07/highlights-of-development-sprint-13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/01/07/index.html
+++ b/2016/01/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/01/10/index.html
+++ b/2016/01/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/01/10/li-f-e-at-bita-show-2016/index.html
+++ b/2016/01/10/li-f-e-at-bita-show-2016/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/01/18/a-brief-360-overview-of-my-first-board-turn/index.html
+++ b/2016/01/18/a-brief-360-overview-of-my-first-board-turn/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/01/18/index.html
+++ b/2016/01/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/01/29/index.html
+++ b/2016/01/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/01/29/running-live-image-from-ram/index.html
+++ b/2016/01/29/running-live-image-from-ram/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/01/index.html
+++ b/2016/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/02/03/highlights-of-development-sprint-14/index.html
+++ b/2016/02/03/highlights-of-development-sprint-14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/02/03/index.html
+++ b/2016/02/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/02/17/index.html
+++ b/2016/02/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/02/17/sugar-on-opensuse/index.html
+++ b/2016/02/17/sugar-on-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/02/25/highlights-of-development-sprint-15/index.html
+++ b/2016/02/25/highlights-of-development-sprint-15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/02/25/index.html
+++ b/2016/02/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/02/27/index.html
+++ b/2016/02/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/02/27/tosprint-or-not-to-sprint/index.html
+++ b/2016/02/27/tosprint-or-not-to-sprint/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/02/index.html
+++ b/2016/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/03/15/highlights-of-development-sprint-16/index.html
+++ b/2016/03/15/highlights-of-development-sprint-16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/03/15/index.html
+++ b/2016/03/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/03/17/amd-catalyst-15-12-for-opensuse-new-makerpm-amd-script-is-available/index.html
+++ b/2016/03/17/amd-catalyst-15-12-for-opensuse-new-makerpm-amd-script-is-available/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/03/17/index.html
+++ b/2016/03/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/03/index.html
+++ b/2016/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/04/06/index.html
+++ b/2016/04/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/04/index.html
+++ b/2016/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/05/02/highlights-of-yast-development-sprint-18/index.html
+++ b/2016/05/02/highlights-of-yast-development-sprint-18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/05/02/index.html
+++ b/2016/05/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/05/18/highlights-of-yast-development-sprint-19/index.html
+++ b/2016/05/18/highlights-of-yast-development-sprint-19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/05/18/index.html
+++ b/2016/05/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/05/index.html
+++ b/2016/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/06/07/highlights-of-yast-development-sprint-20/index.html
+++ b/2016/06/07/highlights-of-yast-development-sprint-20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/06/07/index.html
+++ b/2016/06/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/06/23/highlights-of-yast-development-sprint-21/index.html
+++ b/2016/06/23/highlights-of-yast-development-sprint-21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/06/23/index.html
+++ b/2016/06/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/06/index.html
+++ b/2016/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/07/04/future-of-li-f-e-linux-for-education-distribution/index.html
+++ b/2016/07/04/future-of-li-f-e-linux-for-education-distribution/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/07/04/index.html
+++ b/2016/07/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/07/11/index.html
+++ b/2016/07/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/07/11/zypper-patch-uninstall-rollback/index.html
+++ b/2016/07/11/zypper-patch-uninstall-rollback/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/07/21/index.html
+++ b/2016/07/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/07/21/tally-erp-9-on-linux/index.html
+++ b/2016/07/21/tally-erp-9-on-linux/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/07/27/highlights-of-yast-development-sprint-22/index.html
+++ b/2016/07/27/highlights-of-yast-development-sprint-22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/07/27/index.html
+++ b/2016/07/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/07/index.html
+++ b/2016/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/08/11/index.html
+++ b/2016/08/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/08/11/result-of-opensuse-asia-summit-2016-logo-contest/index.html
+++ b/2016/08/11/result-of-opensuse-asia-summit-2016-logo-contest/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/08/14/index.html
+++ b/2016/08/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/08/14/live-usb-improvements/index.html
+++ b/2016/08/14/live-usb-improvements/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/08/18/index.html
+++ b/2016/08/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/08/index.html
+++ b/2016/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/09/07/highlights-of-yast-development-sprint-24/index.html
+++ b/2016/09/07/highlights-of-yast-development-sprint-24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/09/07/index.html
+++ b/2016/09/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/09/28/highlights-of-yast-development-sprint-25/index.html
+++ b/2016/09/28/highlights-of-yast-development-sprint-25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/09/28/index.html
+++ b/2016/09/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/09/index.html
+++ b/2016/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/10/03/atualizando-o-edison-intel-no-opensuse/index.html
+++ b/2016/10/03/atualizando-o-edison-intel-no-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/10/03/index.html
+++ b/2016/10/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/10/07/index.html
+++ b/2016/10/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/10/11/index.html
+++ b/2016/10/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/10/11/reducing-yast-rebuild-time-by-30/index.html
+++ b/2016/10/11/reducing-yast-rebuild-time-by-30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/10/15/index.html
+++ b/2016/10/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/10/15/proprietary-amdati-catalyst-fglrx-15-12-rpms-released-for-leap-42-2/index.html
+++ b/2016/10/15/proprietary-amdati-catalyst-fglrx-15-12-rpms-released-for-leap-42-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/10/20/highlights-of-yast-development-sprint-26/index.html
+++ b/2016/10/20/highlights-of-yast-development-sprint-26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/10/20/index.html
+++ b/2016/10/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/10/28/index.html
+++ b/2016/10/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/10/28/nextcloud-installation-on-opensuse-leap/index.html
+++ b/2016/10/28/nextcloud-installation-on-opensuse-leap/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/10/index.html
+++ b/2016/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/11/10/highlights-of-yast-development-sprint-27/index.html
+++ b/2016/11/10/highlights-of-yast-development-sprint-27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/11/10/index.html
+++ b/2016/11/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/11/23/index.html
+++ b/2016/11/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/11/23/yast-team-visits-euruko-2016/index.html
+++ b/2016/11/23/yast-team-visits-euruko-2016/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/11/29/index.html
+++ b/2016/11/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/11/29/opensuse-project-presentation-at-school-nov-24th-2016/index.html
+++ b/2016/11/29/opensuse-project-presentation-at-school-nov-24th-2016/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/11/index.html
+++ b/2016/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/12/02/highlights-of-yast-development-sprint-28/index.html
+++ b/2016/12/02/highlights-of-yast-development-sprint-28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/12/02/index.html
+++ b/2016/12/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/12/07/amdati-catalyst-fglrx-rpms-end-of-an-era/index.html
+++ b/2016/12/07/amdati-catalyst-fglrx-rpms-end-of-an-era/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/12/07/index.html
+++ b/2016/12/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/12/22/highlights-of-yast-development-sprint-29/index.html
+++ b/2016/12/22/highlights-of-yast-development-sprint-29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/12/22/index.html
+++ b/2016/12/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/12/26/how-to-build-os-images-without-kiwi/index.html
+++ b/2016/12/26/how-to-build-os-images-without-kiwi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/12/26/index.html
+++ b/2016/12/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/12/29/index.html
+++ b/2016/12/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/12/29/watching-360-video-on-opensuse/index.html
+++ b/2016/12/29/watching-360-video-on-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/12/index.html
+++ b/2016/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/index.html
+++ b/2016/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/page/2/index.html
+++ b/2016/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/page/3/index.html
+++ b/2016/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2016/page/4/index.html
+++ b/2016/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/01/06/index.html
+++ b/2017/01/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/01/06/owasp-zap-official-rpm-package-in-opensuse/index.html
+++ b/2017/01/06/owasp-zap-official-rpm-package-in-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/01/23/how-we-run-our-openstack-cloud/index.html
+++ b/2017/01/23/how-we-run-our-openstack-cloud/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/01/23/index.html
+++ b/2017/01/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/01/index.html
+++ b/2017/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/02/03/index.html
+++ b/2017/02/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/02/16/fun-things-to-do-with-driver-updates/index.html
+++ b/2017/02/16/fun-things-to-do-with-driver-updates/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/02/16/index.html
+++ b/2017/02/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/02/20/highlights-of-yast-development-sprint-31/index.html
+++ b/2017/02/20/highlights-of-yast-development-sprint-31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/02/20/index.html
+++ b/2017/02/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/02/index.html
+++ b/2017/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/03/07/index.html
+++ b/2017/03/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/03/07/yast-development-during-hack-week-15/index.html
+++ b/2017/03/07/yast-development-during-hack-week-15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/03/16/fun-things-to-do-with-driver-updates-2/index.html
+++ b/2017/03/16/fun-things-to-do-with-driver-updates-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/03/16/index.html
+++ b/2017/03/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/03/22/highlights-of-yast-development-sprint-32/index.html
+++ b/2017/03/22/highlights-of-yast-development-sprint-32/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/03/22/index.html
+++ b/2017/03/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/03/index.html
+++ b/2017/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/04/25/fun-things-to-do-with-driver-updates-3/index.html
+++ b/2017/04/25/fun-things-to-do-with-driver-updates-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/04/25/index.html
+++ b/2017/04/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/04/26/highlights-of-yast-development-sprint-33/index.html
+++ b/2017/04/26/highlights-of-yast-development-sprint-33/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/04/26/index.html
+++ b/2017/04/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/04/index.html
+++ b/2017/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/05/03/highlights-of-yast-development-sprint-34/index.html
+++ b/2017/05/03/highlights-of-yast-development-sprint-34/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/05/03/index.html
+++ b/2017/05/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/05/17/cfa-config-files-api-at-a-glance/index.html
+++ b/2017/05/17/cfa-config-files-api-at-a-glance/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/05/17/index.html
+++ b/2017/05/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/05/25/index.html
+++ b/2017/05/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/05/25/yast-sprint-35/index.html
+++ b/2017/05/25/yast-sprint-35/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/05/26/index.html
+++ b/2017/05/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/05/26/manual-paritioning-crypttab/index.html
+++ b/2017/05/26/manual-paritioning-crypttab/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/05/index.html
+++ b/2017/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/06/04/index.html
+++ b/2017/06/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/06/04/the-issues-with-contributing-to-projects-only-once/index.html
+++ b/2017/06/04/the-issues-with-contributing-to-projects-only-once/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/06/16/index.html
+++ b/2017/06/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/06/16/yast-sprint-36/index.html
+++ b/2017/06/16/yast-sprint-36/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/06/index.html
+++ b/2017/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/07/03/index.html
+++ b/2017/07/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/07/03/yast-sprint-37/index.html
+++ b/2017/07/03/yast-sprint-37/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/07/14/index.html
+++ b/2017/07/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -542,7 +537,6 @@ img.emoji {
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/2017/07/14/yast-sprint-38/index.html
+++ b/2017/07/14/yast-sprint-38/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -613,7 +608,6 @@ img.emoji {
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/comment-reply.min.js?ver=4.7.5'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/2017/07/25/increase-the-threadprocess-limit-for-chrome-and-chromium-to-prevent-unable-to-create-process-errors/index.html
+++ b/2017/07/25/increase-the-threadprocess-limit-for-chrome-and-chromium-to-prevent-unable-to-create-process-errors/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/07/25/index.html
+++ b/2017/07/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/07/31/index.html
+++ b/2017/07/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/07/31/yast-sprint-39/index.html
+++ b/2017/07/31/yast-sprint-39/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/07/index.html
+++ b/2017/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -721,7 +716,6 @@ jdoe        hard    nproc   16384</code></p>
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/2017/08/10/highlights-of-yast-development-sprint-40/index.html
+++ b/2017/08/10/highlights-of-yast-development-sprint-40/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/08/10/index.html
+++ b/2017/08/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/08/18/developing-with-openssl-1-1-x-on-opensuse-leap/index.html
+++ b/2017/08/18/developing-with-openssl-1-1-x-on-opensuse-leap/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/08/18/index.html
+++ b/2017/08/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/08/24/index.html
+++ b/2017/08/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/08/24/yast-sprint-41/index.html
+++ b/2017/08/24/yast-sprint-41/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/08/29/index.html
+++ b/2017/08/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/08/29/new-blog-cyberorg-wordpress-com/index.html
+++ b/2017/08/29/new-blog-cyberorg-wordpress-com/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/08/index.html
+++ b/2017/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/09/07/highlights-of-yast-development-sprint-42/index.html
+++ b/2017/09/07/highlights-of-yast-development-sprint-42/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/09/07/index.html
+++ b/2017/09/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/09/21/index.html
+++ b/2017/09/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/09/21/suse-support-lands-upstream-in-cloud-init/index.html
+++ b/2017/09/21/suse-support-lands-upstream-in-cloud-init/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/09/21/yast-sprint-43/index.html
+++ b/2017/09/21/yast-sprint-43/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/09/index.html
+++ b/2017/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/10/11/index.html
+++ b/2017/10/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/10/11/yast-sprint-44/index.html
+++ b/2017/10/11/yast-sprint-44/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/10/25/highlights-of-yast-development-sprint-45/index.html
+++ b/2017/10/25/highlights-of-yast-development-sprint-45/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/10/25/index.html
+++ b/2017/10/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/10/index.html
+++ b/2017/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/11/10/index.html
+++ b/2017/11/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/11/10/yast-sprint-46/index.html
+++ b/2017/11/10/yast-sprint-46/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/11/17/encrypted-installation-media/index.html
+++ b/2017/11/17/encrypted-installation-media/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/11/17/index.html
+++ b/2017/11/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/11/index.html
+++ b/2017/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/12/07/highlights-of-yast-development-sprint-47/index.html
+++ b/2017/12/07/highlights-of-yast-development-sprint-47/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/12/07/index.html
+++ b/2017/12/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/12/index.html
+++ b/2017/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/index.html
+++ b/2017/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/page/2/index.html
+++ b/2017/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -1103,7 +1098,6 @@ the installation command line, it usually means that a reboot of the machine is 
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/2017/page/3/index.html
+++ b/2017/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2017/page/4/index.html
+++ b/2017/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/01/09/highlights-of-yast-development-sprint-48/index.html
+++ b/2018/01/09/highlights-of-yast-development-sprint-48/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/01/09/index.html
+++ b/2018/01/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/01/25/index.html
+++ b/2018/01/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/01/25/yast-sprint-49/index.html
+++ b/2018/01/25/yast-sprint-49/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/01/index.html
+++ b/2018/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/02/09/highlights-of-yast-development-sprint-50/index.html
+++ b/2018/02/09/highlights-of-yast-development-sprint-50/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/02/09/index.html
+++ b/2018/02/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/02/22/highlights-of-yast-development-sprint-51/index.html
+++ b/2018/02/22/highlights-of-yast-development-sprint-51/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/02/22/index.html
+++ b/2018/02/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/02/index.html
+++ b/2018/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/03/09/highlights-of-yast-development-sprint-52/index.html
+++ b/2018/03/09/highlights-of-yast-development-sprint-52/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/03/09/index.html
+++ b/2018/03/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/03/23/index.html
+++ b/2018/03/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/03/23/yast-sprint-53/index.html
+++ b/2018/03/23/yast-sprint-53/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/03/index.html
+++ b/2018/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/04/11/highlights-of-yast-development-sprint-54/index.html
+++ b/2018/04/11/highlights-of-yast-development-sprint-54/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/04/11/index.html
+++ b/2018/04/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/04/24/highlights-of-yast-development-sprint-55/index.html
+++ b/2018/04/24/highlights-of-yast-development-sprint-55/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/04/24/index.html
+++ b/2018/04/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/04/index.html
+++ b/2018/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/05/08/highlights-of-yast-development-sprint-56/index.html
+++ b/2018/05/08/highlights-of-yast-development-sprint-56/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/05/08/index.html
+++ b/2018/05/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/05/31/index.html
+++ b/2018/05/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/05/31/yast-sprint-57/index.html
+++ b/2018/05/31/yast-sprint-57/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/05/index.html
+++ b/2018/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/07/05/index.html
+++ b/2018/07/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/07/05/yast-development-update/index.html
+++ b/2018/07/05/yast-development-update/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/07/23/index.html
+++ b/2018/07/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/07/23/yast-squad-sprint-58/index.html
+++ b/2018/07/23/yast-squad-sprint-58/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/07/index.html
+++ b/2018/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/08/07/index.html
+++ b/2018/08/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/08/07/zypper-upgraderepo-plugin-is-here/index.html
+++ b/2018/08/07/zypper-upgraderepo-plugin-is-here/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/08/22/index.html
+++ b/2018/08/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/08/22/yast-squad-sprint-59-60/index.html
+++ b/2018/08/22/yast-squad-sprint-59-60/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/08/29/index.html
+++ b/2018/08/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/08/29/yast-sprint-61/index.html
+++ b/2018/08/29/yast-sprint-61/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/08/index.html
+++ b/2018/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/09/12/index.html
+++ b/2018/09/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/09/12/yast-squad-sprint-62/index.html
+++ b/2018/09/12/yast-squad-sprint-62/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/09/index.html
+++ b/2018/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/10/01/index.html
+++ b/2018/10/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/10/01/yast-sprint-63/index.html
+++ b/2018/10/01/yast-sprint-63/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/10/09/index.html
+++ b/2018/10/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/10/09/yast-sprint-64/index.html
+++ b/2018/10/09/yast-sprint-64/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/10/23/highlights-of-yast-development-sprint-65/index.html
+++ b/2018/10/23/highlights-of-yast-development-sprint-65/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/10/23/index.html
+++ b/2018/10/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/10/index.html
+++ b/2018/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/11/07/highlights-of-yast-development-sprint-66/index.html
+++ b/2018/11/07/highlights-of-yast-development-sprint-66/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/11/07/index.html
+++ b/2018/11/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/11/20/index.html
+++ b/2018/11/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/11/20/yast-sprint-67/index.html
+++ b/2018/11/20/yast-sprint-67/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/11/index.html
+++ b/2018/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/12/04/highlights-of-yast-development-sprint-68/index.html
+++ b/2018/12/04/highlights-of-yast-development-sprint-68/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/12/04/index.html
+++ b/2018/12/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/12/17/index.html
+++ b/2018/12/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/12/17/report-from-the-reproducible-builds-summit-2018/index.html
+++ b/2018/12/17/report-from-the-reproducible-builds-summit-2018/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/12/index.html
+++ b/2018/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/index.html
+++ b/2018/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/page/2/index.html
+++ b/2018/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2018/page/3/index.html
+++ b/2018/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/01/31/highlights-of-yast-development-sprint-6970/index.html
+++ b/2019/01/31/highlights-of-yast-development-sprint-6970/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/01/31/index.html
+++ b/2019/01/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/01/index.html
+++ b/2019/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/02/01/index.html
+++ b/2019/02/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/02/01/replacing-github-services-with-github-webhooks/index.html
+++ b/2019/02/01/replacing-github-services-with-github-webhooks/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/02/23/index.html
+++ b/2019/02/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/02/23/zypper-upgraderepo-1-2-is-out/index.html
+++ b/2019/02/23/zypper-upgraderepo-1-2-is-out/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/02/27/getting-yast-cm-up-to-date/index.html
+++ b/2019/02/27/getting-yast-cm-up-to-date/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/02/27/index.html
+++ b/2019/02/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/02/27/recap-bcache-in-yast/index.html
+++ b/2019/02/27/recap-bcache-in-yast/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/02/27/yast-sprint-71-72/index.html
+++ b/2019/02/27/yast-sprint-71-72/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/02/index.html
+++ b/2019/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/03/14/index.html
+++ b/2019/03/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/03/14/yast-sprint-73/index.html
+++ b/2019/03/14/yast-sprint-73/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/03/29/highlights-of-yast-development-sprint-74/index.html
+++ b/2019/03/29/highlights-of-yast-development-sprint-74/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/03/29/index.html
+++ b/2019/03/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/03/31/index.html
+++ b/2019/03/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/03/31/zegnamy-forum-suse-pl-i-witamy-forums-opensuse-org/index.html
+++ b/2019/03/31/zegnamy-forum-suse-pl-i-witamy-forums-opensuse-org/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/03/index.html
+++ b/2019/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/04/03/experimental-opensuse-mirror-via-ipfs/index.html
+++ b/2019/04/03/experimental-opensuse-mirror-via-ipfs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/04/03/index.html
+++ b/2019/04/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/04/10/index.html
+++ b/2019/04/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/04/10/yast-sprint-75/index.html
+++ b/2019/04/10/yast-sprint-75/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/04/26/announcing-libyui-testing-framework/index.html
+++ b/2019/04/26/announcing-libyui-testing-framework/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/04/26/index.html
+++ b/2019/04/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/04/30/highlights-of-yast-development-sprint-76/index.html
+++ b/2019/04/30/highlights-of-yast-development-sprint-76/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/04/30/index.html
+++ b/2019/04/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/04/index.html
+++ b/2019/04/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/06/19/getting-further-with-btrfs-in-yast/index.html
+++ b/2019/06/19/getting-further-with-btrfs-in-yast/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/06/19/index.html
+++ b/2019/06/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/06/25/index.html
+++ b/2019/06/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/06/25/yast-sprints-77-79/index.html
+++ b/2019/06/25/yast-sprints-77-79/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/06/index.html
+++ b/2019/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/07/16/index.html
+++ b/2019/07/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/07/16/suse-manager-guided-setup/index.html
+++ b/2019/07/16/suse-manager-guided-setup/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/07/19/index.html
+++ b/2019/07/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/07/19/yast-sprint-80/index.html
+++ b/2019/07/19/yast-sprint-80/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/07/29/highlights-of-yast-development-sprint-81/index.html
+++ b/2019/07/29/highlights-of-yast-development-sprint-81/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/07/29/index.html
+++ b/2019/07/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/07/31/debugging-jenkins/index.html
+++ b/2019/07/31/debugging-jenkins/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/07/31/index.html
+++ b/2019/07/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/07/index.html
+++ b/2019/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/08/07/index.html
+++ b/2019/08/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/08/07/tricks-with-ipfs/index.html
+++ b/2019/08/07/tricks-with-ipfs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/08/14/index.html
+++ b/2019/08/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/08/14/yast-sprint-82/index.html
+++ b/2019/08/14/yast-sprint-82/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/08/30/index.html
+++ b/2019/08/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/08/30/yast-sprint-83/index.html
+++ b/2019/08/30/yast-sprint-83/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/08/index.html
+++ b/2019/08/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/09/13/index.html
+++ b/2019/09/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/09/13/opensuse-obs-git-mirror/index.html
+++ b/2019/09/13/opensuse-obs-git-mirror/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/09/16/index.html
+++ b/2019/09/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/09/16/yast-sprint-84/index.html
+++ b/2019/09/16/yast-sprint-84/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/09/26/highlights-of-yast-development-sprint-85/index.html
+++ b/2019/09/26/highlights-of-yast-development-sprint-85/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/09/26/index.html
+++ b/2019/09/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/09/index.html
+++ b/2019/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/10/09/advanced-encryption-yast/index.html
+++ b/2019/10/09/advanced-encryption-yast/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/10/09/index.html
+++ b/2019/10/09/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/10/09/opensuse-wsl-images-in-obs/index.html
+++ b/2019/10/09/opensuse-wsl-images-in-obs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/10/23/index.html
+++ b/2019/10/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/10/23/yast-sprint-87/index.html
+++ b/2019/10/23/yast-sprint-87/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/10/index.html
+++ b/2019/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/11/21/index.html
+++ b/2019/11/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/11/21/using-yast-firstboot-wizard-in-wsl/index.html
+++ b/2019/11/21/using-yast-firstboot-wizard-in-wsl/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/11/22/highlights-of-yast-development-sprints-88-and-89/index.html
+++ b/2019/11/22/highlights-of-yast-development-sprints-88-and-89/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/11/22/index.html
+++ b/2019/11/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/11/index.html
+++ b/2019/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/12/05/index.html
+++ b/2019/12/05/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/12/05/yast-sprint-90/index.html
+++ b/2019/12/05/yast-sprint-90/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/12/13/index.html
+++ b/2019/12/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/12/13/opensuse-on-reproducible-builds-summit/index.html
+++ b/2019/12/13/opensuse-on-reproducible-builds-summit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/12/18/index.html
+++ b/2019/12/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/12/18/yast-sprint-91/index.html
+++ b/2019/12/18/yast-sprint-91/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/12/index.html
+++ b/2019/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/index.html
+++ b/2019/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/page/2/index.html
+++ b/2019/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/page/3/index.html
+++ b/2019/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2019/page/4/index.html
+++ b/2019/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2020/01/24/highlights-of-yast-development-sprint-92/index.html
+++ b/2020/01/24/highlights-of-yast-development-sprint-92/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2020/01/24/index.html
+++ b/2020/01/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2020/01/index.html
+++ b/2020/01/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2020/02/07/index.html
+++ b/2020/02/07/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2020/02/07/yast-sprint-93/index.html
+++ b/2020/02/07/yast-sprint-93/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2020/02/16/index.html
+++ b/2020/02/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2020/02/16/micro-opensuse-leap-15-1-for-aws/index.html
+++ b/2020/02/16/micro-opensuse-leap-15-1-for-aws/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2020/02/index.html
+++ b/2020/02/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2020/03/06/index.html
+++ b/2020/03/06/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2020/03/06/yast-sprint-94/index.html
+++ b/2020/03/06/yast-sprint-94/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2020/03/index.html
+++ b/2020/03/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/2020/index.html
+++ b/2020/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/a_jaeger/index.html
+++ b/author/a_jaeger/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/a_jaeger/page/2/index.html
+++ b/author/a_jaeger/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/a_jaeger/page/3/index.html
+++ b/author/a_jaeger/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/a_jaeger/page/4/index.html
+++ b/author/a_jaeger/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/a_jaeger/page/5/index.html
+++ b/author/a_jaeger/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/a_jaeger/page/6/index.html
+++ b/author/a_jaeger/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/a_jaeger/page/7/index.html
+++ b/author/a_jaeger/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/adriansuse/index.html
+++ b/author/adriansuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/adriansuse/page/2/index.html
+++ b/author/adriansuse/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/alexander_naumov/index.html
+++ b/author/alexander_naumov/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/alexbariv/index.html
+++ b/author/alexbariv/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/alexbariv/page/2/index.html
+++ b/author/alexbariv/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/amonthoth/index.html
+++ b/author/amonthoth/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/andreasstieger/index.html
+++ b/author/andreasstieger/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/andreasstieger/page/2/index.html
+++ b/author/andreasstieger/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/ansus/index.html
+++ b/author/ansus/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/anubisg1/index.html
+++ b/author/anubisg1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/anubisg1/page/2/index.html
+++ b/author/anubisg1/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/anubisg1/page/3/index.html
+++ b/author/anubisg1/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/aorlovskyy/index.html
+++ b/author/aorlovskyy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/aschnell/index.html
+++ b/author/aschnell/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/babelworx/index.html
+++ b/author/babelworx/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/badshah400/index.html
+++ b/author/badshah400/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bmwiedemann/index.html
+++ b/author/bmwiedemann/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bmwiedemann/page/2/index.html
+++ b/author/bmwiedemann/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bmwiedemann/page/3/index.html
+++ b/author/bmwiedemann/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bmwiedemann/page/4/index.html
+++ b/author/bmwiedemann/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bruno_friedmann/index.html
+++ b/author/bruno_friedmann/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bruno_friedmann/page/10/index.html
+++ b/author/bruno_friedmann/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bruno_friedmann/page/2/index.html
+++ b/author/bruno_friedmann/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bruno_friedmann/page/3/index.html
+++ b/author/bruno_friedmann/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bruno_friedmann/page/4/index.html
+++ b/author/bruno_friedmann/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bruno_friedmann/page/5/index.html
+++ b/author/bruno_friedmann/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bruno_friedmann/page/6/index.html
+++ b/author/bruno_friedmann/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bruno_friedmann/page/7/index.html
+++ b/author/bruno_friedmann/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bruno_friedmann/page/8/index.html
+++ b/author/bruno_friedmann/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/bruno_friedmann/page/9/index.html
+++ b/author/bruno_friedmann/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/cabelo/index.html
+++ b/author/cabelo/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/cabelo/page/2/index.html
+++ b/author/cabelo/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/caf4926/index.html
+++ b/author/caf4926/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/calumma/index.html
+++ b/author/calumma/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/calumma/page/2/index.html
+++ b/author/calumma/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/calumma/page/3/index.html
+++ b/author/calumma/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/coolo/index.html
+++ b/author/coolo/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/coolo/page/2/index.html
+++ b/author/coolo/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/cyberiad/index.html
+++ b/author/cyberiad/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/cyberorg/index.html
+++ b/author/cyberorg/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/cyberorg/page/2/index.html
+++ b/author/cyberorg/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/cyberorg/page/3/index.html
+++ b/author/cyberorg/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/cyberorg/page/4/index.html
+++ b/author/cyberorg/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/cyberorg/page/5/index.html
+++ b/author/cyberorg/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/cyberorg/page/6/index.html
+++ b/author/cyberorg/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/cyberorg/page/7/index.html
+++ b/author/cyberorg/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/cyberorg/page/8/index.html
+++ b/author/cyberorg/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/cyberorg/page/9/index.html
+++ b/author/cyberorg/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/diamond_gr/index.html
+++ b/author/diamond_gr/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/diamond_gr/page/2/index.html
+++ b/author/diamond_gr/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/diamond_gr/page/3/index.html
+++ b/author/diamond_gr/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/digitaltomm/index.html
+++ b/author/digitaltomm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/dirkmueller/index.html
+++ b/author/dirkmueller/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/dj_ubun_1/index.html
+++ b/author/dj_ubun_1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/dl9pf/index.html
+++ b/author/dl9pf/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/dl9pf/page/2/index.html
+++ b/author/dl9pf/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/dmitry_serpokryl/index.html
+++ b/author/dmitry_serpokryl/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/ealin/index.html
+++ b/author/ealin/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/eri_zaq/index.html
+++ b/author/eri_zaq/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/fabiomux/index.html
+++ b/author/fabiomux/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/flucifredi/index.html
+++ b/author/flucifredi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/freespacer/index.html
+++ b/author/freespacer/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/froh/index.html
+++ b/author/froh/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/funkypenguin/index.html
+++ b/author/funkypenguin/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/funkypenguin/page/2/index.html
+++ b/author/funkypenguin/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/funkypenguin/page/3/index.html
+++ b/author/funkypenguin/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/funkypenguin/page/4/index.html
+++ b/author/funkypenguin/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/g0nz0/index.html
+++ b/author/g0nz0/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/ganglia/index.html
+++ b/author/ganglia/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/gogga/index.html
+++ b/author/gogga/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/gregfreemyer/index.html
+++ b/author/gregfreemyer/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/haass/index.html
+++ b/author/haass/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/helcaraxe/index.html
+++ b/author/helcaraxe/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/hobbsc/index.html
+++ b/author/hobbsc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/hobbsc/page/2/index.html
+++ b/author/hobbsc/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/holden87/index.html
+++ b/author/holden87/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/holgisms/index.html
+++ b/author/holgisms/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/idulk/index.html
+++ b/author/idulk/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/illuusio/index.html
+++ b/author/illuusio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/illuusio/page/2/index.html
+++ b/author/illuusio/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/illuusio/page/3/index.html
+++ b/author/illuusio/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/illuusio/page/4/index.html
+++ b/author/illuusio/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/jan-portugal/index.html
+++ b/author/jan-portugal/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/janblunck/index.html
+++ b/author/janblunck/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/jaom7/index.html
+++ b/author/jaom7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/jasujt/index.html
+++ b/author/jasujt/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/javierllorente/index.html
+++ b/author/javierllorente/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/javierllorente/page/2/index.html
+++ b/author/javierllorente/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/jdsn/index.html
+++ b/author/jdsn/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/jloeser/index.html
+++ b/author/jloeser/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/jnweiger/index.html
+++ b/author/jnweiger/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/jreidinger/index.html
+++ b/author/jreidinger/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/jreidinger/page/2/index.html
+++ b/author/jreidinger/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/jsrain/index.html
+++ b/author/jsrain/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/jsuchome/index.html
+++ b/author/jsuchome/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/k0da/index.html
+++ b/author/k0da/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/kdupuy9/index.html
+++ b/author/kdupuy9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/kdupuy9/page/2/index.html
+++ b/author/kdupuy9/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/ketheriel/index.html
+++ b/author/ketheriel/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/ketheriel/page/2/index.html
+++ b/author/ketheriel/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/ketheriel/page/3/index.html
+++ b/author/ketheriel/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/ketheriel/page/4/index.html
+++ b/author/ketheriel/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/ketheriel/page/5/index.html
+++ b/author/ketheriel/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/ketheriel/page/6/index.html
+++ b/author/ketheriel/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/kfreitag/index.html
+++ b/author/kfreitag/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/kfreitag/page/2/index.html
+++ b/author/kfreitag/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/kfreitag/page/3/index.html
+++ b/author/kfreitag/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/kfreitag/page/4/index.html
+++ b/author/kfreitag/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/kfreitag/page/5/index.html
+++ b/author/kfreitag/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/kfreitag/page/6/index.html
+++ b/author/kfreitag/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/kurniawan-007/index.html
+++ b/author/kurniawan-007/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/lnussel/index.html
+++ b/author/lnussel/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/lnussel/page/2/index.html
+++ b/author/lnussel/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/lrupp/index.html
+++ b/author/lrupp/index.html
@@ -23,15 +23,10 @@
 I like to give a very subjective overview about the current state, so the rumors have something to eat ;-)" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/lrupp/page/2/index.html
+++ b/author/lrupp/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/marcus_h/index.html
+++ b/author/marcus_h/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/marcus_h/page/2/index.html
+++ b/author/marcus_h/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/marcus_h/page/3/index.html
+++ b/author/marcus_h/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/marcus_h/page/4/index.html
+++ b/author/marcus_h/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/marcusmoeller/index.html
+++ b/author/marcusmoeller/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/martinmohring/index.html
+++ b/author/martinmohring/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/martinmohring/page/2/index.html
+++ b/author/martinmohring/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/medwin/index.html
+++ b/author/medwin/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/michal-m/index.html
+++ b/author/michal-m/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/michl19/index.html
+++ b/author/michl19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/migbarajas/index.html
+++ b/author/migbarajas/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/mlandres/index.html
+++ b/author/mlandres/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/mlasars/index.html
+++ b/author/mlasars/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/mrdocs/index.html
+++ b/author/mrdocs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/msmeissn/index.html
+++ b/author/msmeissn/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Brief report on the Wine talk at LinuxTag 2011 in Berlin, by Christian Boltz and Marcus Meissner. " />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/mvyskocil/index.html
+++ b/author/mvyskocil/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/mvyskocil/page/2/index.html
+++ b/author/mvyskocil/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/namtrac/index.html
+++ b/author/namtrac/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/nikanth/index.html
+++ b/author/nikanth/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/pbojczuk/index.html
+++ b/author/pbojczuk/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/pgajdos/index.html
+++ b/author/pgajdos/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/pmladek/index.html
+++ b/author/pmladek/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/pmladek/page/2/index.html
+++ b/author/pmladek/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/pmladek/page/3/index.html
+++ b/author/pmladek/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/pmladek/page/4/index.html
+++ b/author/pmladek/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/pmladek/page/5/index.html
+++ b/author/pmladek/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/pmladek/page/6/index.html
+++ b/author/pmladek/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/poeml/index.html
+++ b/author/poeml/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/puzel/index.html
+++ b/author/puzel/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/rawang/index.html
+++ b/author/rawang/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/rbos/index.html
+++ b/author/rbos/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/rbos/page/2/index.html
+++ b/author/rbos/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/rhorstkoetter/index.html
+++ b/author/rhorstkoetter/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/ricardovarassantana/index.html
+++ b/author/ricardovarassantana/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/rjschwei/index.html
+++ b/author/rjschwei/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/rjschwei/page/2/index.html
+++ b/author/rjschwei/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/rwooninck/index.html
+++ b/author/rwooninck/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/saigkill/index.html
+++ b/author/saigkill/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/saigkill/page/2/index.html
+++ b/author/saigkill/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/saigkill/page/3/index.html
+++ b/author/saigkill/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/saigkill/page/4/index.html
+++ b/author/saigkill/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/saigkill/page/5/index.html
+++ b/author/saigkill/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/saigkill/page/6/index.html
+++ b/author/saigkill/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/saigkill/page/7/index.html
+++ b/author/saigkill/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/sax2/index.html
+++ b/author/sax2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/schubi2/index.html
+++ b/author/schubi2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/sfalken/index.html
+++ b/author/sfalken/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/sh-sh-sh/index.html
+++ b/author/sh-sh-sh/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/sjayaraman/index.html
+++ b/author/sjayaraman/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/snwint/index.html
+++ b/author/snwint/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/tgoettlicher/index.html
+++ b/author/tgoettlicher/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/thomas-schraitle/index.html
+++ b/author/thomas-schraitle/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/thomas-schraitle/page/2/index.html
+++ b/author/thomas-schraitle/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/thomas-schraitle/page/3/index.html
+++ b/author/thomas-schraitle/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/toganm/index.html
+++ b/author/toganm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/ungaman/index.html
+++ b/author/ungaman/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/vavai/index.html
+++ b/author/vavai/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/vavai/page/2/index.html
+++ b/author/vavai/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/visnov/index.html
+++ b/author/visnov/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/wiederda/index.html
+++ b/author/wiederda/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/wstephenson/index.html
+++ b/author/wstephenson/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/wstephenson/page/2/index.html
+++ b/author/wstephenson/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/wstephenson/page/3/index.html
+++ b/author/wstephenson/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/yast-team/index.html
+++ b/author/yast-team/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/yast-team/page/2/index.html
+++ b/author/yast-team/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/yast-team/page/3/index.html
+++ b/author/yast-team/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/yast-team/page/4/index.html
+++ b/author/yast-team/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/yast-team/page/5/index.html
+++ b/author/yast-team/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/yast-team/page/6/index.html
+++ b/author/yast-team/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -1215,7 +1210,6 @@ second stage. But it was still needed for AutoYaST, controlled by the setting</p
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/author/yast-team/page/7/index.html
+++ b/author/yast-team/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/yast-team/page/8/index.html
+++ b/author/yast-team/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/author/yast-team/page/9/index.html
+++ b/author/yast-team/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/accessibility/index.html
+++ b/category/accessibility/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/accessibility/page/2/index.html
+++ b/category/accessibility/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/artwork/index.html
+++ b/category/artwork/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/artwork/page/2/index.html
+++ b/category/artwork/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/artwork/page/3/index.html
+++ b/category/artwork/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/artwork/page/4/index.html
+++ b/category/artwork/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="LXDE" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/artwork/page/5/index.html
+++ b/category/artwork/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/architectures/index.html
+++ b/category/base-system/architectures/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/architectures/page/2/index.html
+++ b/category/base-system/architectures/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/architectures/page/3/index.html
+++ b/category/base-system/architectures/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/index.html
+++ b/category/base-system/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/kernel/index.html
+++ b/category/base-system/kernel/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/kernel/page/2/index.html
+++ b/category/base-system/kernel/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/kernel/page/3/index.html
+++ b/category/base-system/kernel/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/kernel/page/4/index.html
+++ b/category/base-system/kernel/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/kernel/page/5/index.html
+++ b/category/base-system/kernel/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/kernel/page/6/index.html
+++ b/category/base-system/kernel/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/kernel/page/7/index.html
+++ b/category/base-system/kernel/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/kernel/page/8/index.html
+++ b/category/base-system/kernel/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/network/index.html
+++ b/category/base-system/network/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/network/page/2/index.html
+++ b/category/base-system/network/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/network/page/3/index.html
+++ b/category/base-system/network/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/10/index.html
+++ b/category/base-system/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/11/index.html
+++ b/category/base-system/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/12/index.html
+++ b/category/base-system/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/13/index.html
+++ b/category/base-system/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/14/index.html
+++ b/category/base-system/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/15/index.html
+++ b/category/base-system/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/16/index.html
+++ b/category/base-system/page/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/17/index.html
+++ b/category/base-system/page/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/18/index.html
+++ b/category/base-system/page/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/19/index.html
+++ b/category/base-system/page/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/2/index.html
+++ b/category/base-system/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/3/index.html
+++ b/category/base-system/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/4/index.html
+++ b/category/base-system/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/5/index.html
+++ b/category/base-system/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/6/index.html
+++ b/category/base-system/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/7/index.html
+++ b/category/base-system/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/8/index.html
+++ b/category/base-system/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/page/9/index.html
+++ b/category/base-system/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/toolchain/index.html
+++ b/category/base-system/toolchain/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/toolchain/page/2/index.html
+++ b/category/base-system/toolchain/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/base-system/toolchain/page/3/index.html
+++ b/category/base-system/toolchain/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/board/elections/index.html
+++ b/category/board/elections/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/board/elections/page/2/index.html
+++ b/category/board/elections/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/board/index.html
+++ b/category/board/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/board/page/2/index.html
+++ b/category/board/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/board/page/3/index.html
+++ b/category/board/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/boosters/index.html
+++ b/category/boosters/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/boosters/page/2/index.html
+++ b/category/boosters/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/boosters/page/3/index.html
+++ b/category/boosters/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/boosters/page/4/index.html
+++ b/category/boosters/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/boosters/page/5/index.html
+++ b/category/boosters/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/boosters/page/6/index.html
+++ b/category/boosters/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/boosters/page/7/index.html
+++ b/category/boosters/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/index.html
+++ b/category/build-service/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/10/index.html
+++ b/category/build-service/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/11/index.html
+++ b/category/build-service/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/12/index.html
+++ b/category/build-service/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/13/index.html
+++ b/category/build-service/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/14/index.html
+++ b/category/build-service/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/15/index.html
+++ b/category/build-service/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/16/index.html
+++ b/category/build-service/page/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/17/index.html
+++ b/category/build-service/page/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/18/index.html
+++ b/category/build-service/page/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/19/index.html
+++ b/category/build-service/page/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/2/index.html
+++ b/category/build-service/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/20/index.html
+++ b/category/build-service/page/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/3/index.html
+++ b/category/build-service/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/4/index.html
+++ b/category/build-service/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/5/index.html
+++ b/category/build-service/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/6/index.html
+++ b/category/build-service/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/7/index.html
+++ b/category/build-service/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/8/index.html
+++ b/category/build-service/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/build-service/page/9/index.html
+++ b/category/build-service/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/gnome/index.html
+++ b/category/desktop/gnome/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/gnome/page/10/index.html
+++ b/category/desktop/gnome/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/gnome/page/11/index.html
+++ b/category/desktop/gnome/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/gnome/page/12/index.html
+++ b/category/desktop/gnome/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/gnome/page/2/index.html
+++ b/category/desktop/gnome/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/gnome/page/3/index.html
+++ b/category/desktop/gnome/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/gnome/page/4/index.html
+++ b/category/desktop/gnome/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/gnome/page/5/index.html
+++ b/category/desktop/gnome/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/gnome/page/6/index.html
+++ b/category/desktop/gnome/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/gnome/page/7/index.html
+++ b/category/desktop/gnome/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/gnome/page/8/index.html
+++ b/category/desktop/gnome/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/gnome/page/9/index.html
+++ b/category/desktop/gnome/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/index.html
+++ b/category/desktop/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -1020,7 +1015,6 @@ The report was uploaded to sprunge.us.
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/category/desktop/kde/index.html
+++ b/category/desktop/kde/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/kde/page/10/index.html
+++ b/category/desktop/kde/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/kde/page/11/index.html
+++ b/category/desktop/kde/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/kde/page/12/index.html
+++ b/category/desktop/kde/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/kde/page/13/index.html
+++ b/category/desktop/kde/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/kde/page/2/index.html
+++ b/category/desktop/kde/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/kde/page/3/index.html
+++ b/category/desktop/kde/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/kde/page/4/index.html
+++ b/category/desktop/kde/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/kde/page/5/index.html
+++ b/category/desktop/kde/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/kde/page/6/index.html
+++ b/category/desktop/kde/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/kde/page/7/index.html
+++ b/category/desktop/kde/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/kde/page/8/index.html
+++ b/category/desktop/kde/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/kde/page/9/index.html
+++ b/category/desktop/kde/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/mozilla/index.html
+++ b/category/desktop/mozilla/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/openofficeorg/index.html
+++ b/category/desktop/openofficeorg/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/openofficeorg/page/2/index.html
+++ b/category/desktop/openofficeorg/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/openofficeorg/page/3/index.html
+++ b/category/desktop/openofficeorg/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/openofficeorg/page/4/index.html
+++ b/category/desktop/openofficeorg/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/openofficeorg/page/5/index.html
+++ b/category/desktop/openofficeorg/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/openofficeorg/page/6/index.html
+++ b/category/desktop/openofficeorg/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/openofficeorg/page/7/index.html
+++ b/category/desktop/openofficeorg/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/10/index.html
+++ b/category/desktop/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/11/index.html
+++ b/category/desktop/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/12/index.html
+++ b/category/desktop/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/13/index.html
+++ b/category/desktop/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/14/index.html
+++ b/category/desktop/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/15/index.html
+++ b/category/desktop/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/16/index.html
+++ b/category/desktop/page/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/17/index.html
+++ b/category/desktop/page/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/18/index.html
+++ b/category/desktop/page/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/19/index.html
+++ b/category/desktop/page/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/2/index.html
+++ b/category/desktop/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/20/index.html
+++ b/category/desktop/page/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/21/index.html
+++ b/category/desktop/page/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/22/index.html
+++ b/category/desktop/page/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/23/index.html
+++ b/category/desktop/page/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/24/index.html
+++ b/category/desktop/page/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/25/index.html
+++ b/category/desktop/page/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/26/index.html
+++ b/category/desktop/page/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/27/index.html
+++ b/category/desktop/page/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/28/index.html
+++ b/category/desktop/page/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/29/index.html
+++ b/category/desktop/page/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/3/index.html
+++ b/category/desktop/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/30/index.html
+++ b/category/desktop/page/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/31/index.html
+++ b/category/desktop/page/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/32/index.html
+++ b/category/desktop/page/32/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/33/index.html
+++ b/category/desktop/page/33/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/34/index.html
+++ b/category/desktop/page/34/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/35/index.html
+++ b/category/desktop/page/35/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/4/index.html
+++ b/category/desktop/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/5/index.html
+++ b/category/desktop/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/6/index.html
+++ b/category/desktop/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/7/index.html
+++ b/category/desktop/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/8/index.html
+++ b/category/desktop/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/page/9/index.html
+++ b/category/desktop/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/sound/index.html
+++ b/category/desktop/sound/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/xfce/index.html
+++ b/category/desktop/xfce/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/xfce/page/2/index.html
+++ b/category/desktop/xfce/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/xorg/index.html
+++ b/category/desktop/xorg/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/xorg/page/2/index.html
+++ b/category/desktop/xorg/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/xorg/page/3/index.html
+++ b/category/desktop/xorg/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/xorg/page/4/index.html
+++ b/category/desktop/xorg/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/xorg/page/5/index.html
+++ b/category/desktop/xorg/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/desktop/xorg/page/6/index.html
+++ b/category/desktop/xorg/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/contrib/index.html
+++ b/category/distribution/contrib/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/contrib/page/2/index.html
+++ b/category/distribution/contrib/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/contrib/page/3/index.html
+++ b/category/distribution/contrib/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/derivative/index.html
+++ b/category/distribution/derivative/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/derivative/page/2/index.html
+++ b/category/distribution/derivative/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/derivative/page/3/index.html
+++ b/category/distribution/derivative/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/derivative/page/4/index.html
+++ b/category/distribution/derivative/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/derivative/page/5/index.html
+++ b/category/distribution/derivative/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/index.html
+++ b/category/distribution/factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/10/index.html
+++ b/category/distribution/factory/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/11/index.html
+++ b/category/distribution/factory/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/12/index.html
+++ b/category/distribution/factory/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/13/index.html
+++ b/category/distribution/factory/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/14/index.html
+++ b/category/distribution/factory/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/15/index.html
+++ b/category/distribution/factory/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/2/index.html
+++ b/category/distribution/factory/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/3/index.html
+++ b/category/distribution/factory/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/4/index.html
+++ b/category/distribution/factory/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/5/index.html
+++ b/category/distribution/factory/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -1287,7 +1282,6 @@ echo c &gt; /proc/sysrq-trigger</code>
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/category/distribution/factory/page/6/index.html
+++ b/category/distribution/factory/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/7/index.html
+++ b/category/distribution/factory/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/8/index.html
+++ b/category/distribution/factory/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/factory/page/9/index.html
+++ b/category/distribution/factory/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/index.html
+++ b/category/distribution/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/opensuse-112/index.html
+++ b/category/distribution/opensuse-112/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/opensuse-112/page/2/index.html
+++ b/category/distribution/opensuse-112/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/opensuse-112/page/3/index.html
+++ b/category/distribution/opensuse-112/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/opensuse-112/page/4/index.html
+++ b/category/distribution/opensuse-112/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/opensuse-112/page/5/index.html
+++ b/category/distribution/opensuse-112/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/opensuse-112/page/6/index.html
+++ b/category/distribution/opensuse-112/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/opensuse-112/page/7/index.html
+++ b/category/distribution/opensuse-112/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/10/index.html
+++ b/category/distribution/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/11/index.html
+++ b/category/distribution/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/12/index.html
+++ b/category/distribution/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/13/index.html
+++ b/category/distribution/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/14/index.html
+++ b/category/distribution/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/15/index.html
+++ b/category/distribution/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/16/index.html
+++ b/category/distribution/page/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/17/index.html
+++ b/category/distribution/page/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/18/index.html
+++ b/category/distribution/page/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/19/index.html
+++ b/category/distribution/page/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/2/index.html
+++ b/category/distribution/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/20/index.html
+++ b/category/distribution/page/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/21/index.html
+++ b/category/distribution/page/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/22/index.html
+++ b/category/distribution/page/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/23/index.html
+++ b/category/distribution/page/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/24/index.html
+++ b/category/distribution/page/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/25/index.html
+++ b/category/distribution/page/25/index.html
@@ -22,15 +22,10 @@
 Ubuntu is still ahead of openSUSE in some regards of quality. There are things we can learn from them..." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/26/index.html
+++ b/category/distribution/page/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/27/index.html
+++ b/category/distribution/page/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/28/index.html
+++ b/category/distribution/page/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/29/index.html
+++ b/category/distribution/page/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/3/index.html
+++ b/category/distribution/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/30/index.html
+++ b/category/distribution/page/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/31/index.html
+++ b/category/distribution/page/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/32/index.html
+++ b/category/distribution/page/32/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/33/index.html
+++ b/category/distribution/page/33/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/34/index.html
+++ b/category/distribution/page/34/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/35/index.html
+++ b/category/distribution/page/35/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/36/index.html
+++ b/category/distribution/page/36/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/37/index.html
+++ b/category/distribution/page/37/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/38/index.html
+++ b/category/distribution/page/38/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/39/index.html
+++ b/category/distribution/page/39/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/4/index.html
+++ b/category/distribution/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/5/index.html
+++ b/category/distribution/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -1120,7 +1115,6 @@ second stage. But it was still needed for AutoYaST, controlled by the setting</p
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/category/distribution/page/6/index.html
+++ b/category/distribution/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/7/index.html
+++ b/category/distribution/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/8/index.html
+++ b/category/distribution/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/distribution/page/9/index.html
+++ b/category/distribution/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/documentation/index.html
+++ b/category/documentation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/documentation/page/10/index.html
+++ b/category/documentation/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/documentation/page/2/index.html
+++ b/category/documentation/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/documentation/page/3/index.html
+++ b/category/documentation/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/documentation/page/4/index.html
+++ b/category/documentation/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/documentation/page/5/index.html
+++ b/category/documentation/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/documentation/page/6/index.html
+++ b/category/documentation/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/documentation/page/7/index.html
+++ b/category/documentation/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/documentation/page/8/index.html
+++ b/category/documentation/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/documentation/page/9/index.html
+++ b/category/documentation/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/education/index.html
+++ b/category/education/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/education/page/10/index.html
+++ b/category/education/page/10/index.html
@@ -23,15 +23,10 @@
 Working together with many people from different areas of interest - but all with focus on schools and education - needs good and extensive communication to get all "on board driving in nearly one direction". The community week helped us to communicate in our IRC channel and coordinate our effords." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/education/page/2/index.html
+++ b/category/education/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/education/page/3/index.html
+++ b/category/education/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/education/page/4/index.html
+++ b/category/education/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/education/page/5/index.html
+++ b/category/education/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/education/page/6/index.html
+++ b/category/education/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/education/page/7/index.html
+++ b/category/education/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/education/page/8/index.html
+++ b/category/education/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/education/page/9/index.html
+++ b/category/education/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/index.html
+++ b/category/events/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/10/index.html
+++ b/category/events/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/11/index.html
+++ b/category/events/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/12/index.html
+++ b/category/events/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/13/index.html
+++ b/category/events/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/14/index.html
+++ b/category/events/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/15/index.html
+++ b/category/events/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/16/index.html
+++ b/category/events/page/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/17/index.html
+++ b/category/events/page/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/18/index.html
+++ b/category/events/page/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/2/index.html
+++ b/category/events/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/3/index.html
+++ b/category/events/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/4/index.html
+++ b/category/events/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/5/index.html
+++ b/category/events/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/6/index.html
+++ b/category/events/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/7/index.html
+++ b/category/events/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/8/index.html
+++ b/category/events/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/events/page/9/index.html
+++ b/category/events/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/forums/index.html
+++ b/category/forums/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/gsoc-2/index.html
+++ b/category/gsoc-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/gsoc-2/page/2/index.html
+++ b/category/gsoc-2/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/gsoc-2/page/3/index.html
+++ b/category/gsoc-2/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/hackweek/index.html
+++ b/category/hackweek/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/hackweek/page/2/index.html
+++ b/category/hackweek/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/hackweek/page/3/index.html
+++ b/category/hackweek/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/hackweek/page/4/index.html
+++ b/category/hackweek/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/hackweek/page/5/index.html
+++ b/category/hackweek/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/hackweek/page/6/index.html
+++ b/category/hackweek/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/infrastructure-2/index.html
+++ b/category/infrastructure-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/infrastructure-2/page/2/index.html
+++ b/category/infrastructure-2/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/lizardsopensuseorg/index.html
+++ b/category/lizardsopensuseorg/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/lizardsopensuseorg/page/2/index.html
+++ b/category/lizardsopensuseorg/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/lizardsopensuseorg/page/3/index.html
+++ b/category/lizardsopensuseorg/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/lizardsopensuseorg/page/4/index.html
+++ b/category/lizardsopensuseorg/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/lizardsopensuseorg/page/5/index.html
+++ b/category/lizardsopensuseorg/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/lizardsopensuseorg/page/6/index.html
+++ b/category/lizardsopensuseorg/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/lizardsopensuseorg/page/7/index.html
+++ b/category/lizardsopensuseorg/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/lizardsopensuseorg/page/8/index.html
+++ b/category/lizardsopensuseorg/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/lizardsopensuseorg/page/9/index.html
+++ b/category/lizardsopensuseorg/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/localization/index.html
+++ b/category/localization/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/localization/page/2/index.html
+++ b/category/localization/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/ambassadors/index.html
+++ b/category/marketing/ambassadors/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/ambassadors/page/2/index.html
+++ b/category/marketing/ambassadors/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/index.html
+++ b/category/marketing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/page/10/index.html
+++ b/category/marketing/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/page/11/index.html
+++ b/category/marketing/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/page/12/index.html
+++ b/category/marketing/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/page/13/index.html
+++ b/category/marketing/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/page/2/index.html
+++ b/category/marketing/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/page/3/index.html
+++ b/category/marketing/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/page/4/index.html
+++ b/category/marketing/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/page/5/index.html
+++ b/category/marketing/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/page/6/index.html
+++ b/category/marketing/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/page/7/index.html
+++ b/category/marketing/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/page/8/index.html
+++ b/category/marketing/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/marketing/page/9/index.html
+++ b/category/marketing/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/index.html
+++ b/category/miscellaneous/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/10/index.html
+++ b/category/miscellaneous/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/11/index.html
+++ b/category/miscellaneous/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/12/index.html
+++ b/category/miscellaneous/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/13/index.html
+++ b/category/miscellaneous/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/14/index.html
+++ b/category/miscellaneous/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/15/index.html
+++ b/category/miscellaneous/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/16/index.html
+++ b/category/miscellaneous/page/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/17/index.html
+++ b/category/miscellaneous/page/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/2/index.html
+++ b/category/miscellaneous/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/3/index.html
+++ b/category/miscellaneous/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/4/index.html
+++ b/category/miscellaneous/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/5/index.html
+++ b/category/miscellaneous/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/6/index.html
+++ b/category/miscellaneous/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/7/index.html
+++ b/category/miscellaneous/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/8/index.html
+++ b/category/miscellaneous/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/miscellaneous/page/9/index.html
+++ b/category/miscellaneous/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/mono/index.html
+++ b/category/mono/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/packaging/index.html
+++ b/category/packaging/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -1157,7 +1152,6 @@ German Blog: <a href="https://www.sebastian-siebert.de/2015/12/05/opensuse-propr
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/category/packaging/page/10/index.html
+++ b/category/packaging/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/packaging/page/11/index.html
+++ b/category/packaging/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/packaging/page/12/index.html
+++ b/category/packaging/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/packaging/page/13/index.html
+++ b/category/packaging/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/packaging/page/2/index.html
+++ b/category/packaging/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/packaging/page/3/index.html
+++ b/category/packaging/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/packaging/page/4/index.html
+++ b/category/packaging/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/packaging/page/5/index.html
+++ b/category/packaging/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/packaging/page/6/index.html
+++ b/category/packaging/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/packaging/page/7/index.html
+++ b/category/packaging/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/packaging/page/8/index.html
+++ b/category/packaging/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/packaging/page/9/index.html
+++ b/category/packaging/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/programming/index.html
+++ b/category/programming/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/programming/page/10/index.html
+++ b/category/programming/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/programming/page/2/index.html
+++ b/category/programming/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/programming/page/3/index.html
+++ b/category/programming/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -1173,7 +1168,6 @@ Like https://bugzilla.gnome.org/ https://bugs.python.org/ https://bugs.ruby-lang
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/category/programming/page/4/index.html
+++ b/category/programming/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/programming/page/5/index.html
+++ b/category/programming/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/programming/page/6/index.html
+++ b/category/programming/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/programming/page/7/index.html
+++ b/category/programming/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/programming/page/8/index.html
+++ b/category/programming/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/programming/page/9/index.html
+++ b/category/programming/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/quality-assurance/index.html
+++ b/category/quality-assurance/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/quality-assurance/page/2/index.html
+++ b/category/quality-assurance/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/quality-assurance/page/3/index.html
+++ b/category/quality-assurance/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Testing is an important task. But testing daily openSUSE-Factory snapshots would mean testing the same things every day. This would be pretty tiresome to people." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/quality-assurance/page/4/index.html
+++ b/category/quality-assurance/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/security/apparmor/index.html
+++ b/category/security/apparmor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/security/index.html
+++ b/category/security/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/security/page/2/index.html
+++ b/category/security/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/security/page/3/index.html
+++ b/category/security/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/server/apache/index.html
+++ b/category/server/apache/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/server/index.html
+++ b/category/server/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/server/page/2/index.html
+++ b/category/server/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/server/page/3/index.html
+++ b/category/server/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/server/page/4/index.html
+++ b/category/server/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/server/page/5/index.html
+++ b/category/server/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/server/page/6/index.html
+++ b/category/server/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/server/page/7/index.html
+++ b/category/server/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/server/samba/index.html
+++ b/category/server/samba/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/server/virtualization/index.html
+++ b/category/server/virtualization/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/server/virtualization/page/2/index.html
+++ b/category/server/virtualization/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/server/virtualization/page/3/index.html
+++ b/category/server/virtualization/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/index.html
+++ b/category/systems-management/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/10/index.html
+++ b/category/systems-management/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/11/index.html
+++ b/category/systems-management/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/12/index.html
+++ b/category/systems-management/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/13/index.html
+++ b/category/systems-management/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/14/index.html
+++ b/category/systems-management/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/15/index.html
+++ b/category/systems-management/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/16/index.html
+++ b/category/systems-management/page/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/17/index.html
+++ b/category/systems-management/page/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/18/index.html
+++ b/category/systems-management/page/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/19/index.html
+++ b/category/systems-management/page/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/2/index.html
+++ b/category/systems-management/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/20/index.html
+++ b/category/systems-management/page/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/3/index.html
+++ b/category/systems-management/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/4/index.html
+++ b/category/systems-management/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/5/index.html
+++ b/category/systems-management/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/6/index.html
+++ b/category/systems-management/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -1308,7 +1303,6 @@ second stage. But it was still needed for AutoYaST, controlled by the setting</p
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/category/systems-management/page/7/index.html
+++ b/category/systems-management/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/8/index.html
+++ b/category/systems-management/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/page/9/index.html
+++ b/category/systems-management/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/software-management/index.html
+++ b/category/systems-management/software-management/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -1257,7 +1252,6 @@ $ zypper help upgraderepo<br />
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/category/systems-management/software-management/page/2/index.html
+++ b/category/systems-management/software-management/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/software-management/page/3/index.html
+++ b/category/systems-management/software-management/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/software-management/page/4/index.html
+++ b/category/systems-management/software-management/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/software-management/page/5/index.html
+++ b/category/systems-management/software-management/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/index.html
+++ b/category/systems-management/yast/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/page/10/index.html
+++ b/category/systems-management/yast/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/page/11/index.html
+++ b/category/systems-management/yast/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/page/12/index.html
+++ b/category/systems-management/yast/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/page/13/index.html
+++ b/category/systems-management/yast/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/page/14/index.html
+++ b/category/systems-management/yast/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/page/2/index.html
+++ b/category/systems-management/yast/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/page/3/index.html
+++ b/category/systems-management/yast/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/page/4/index.html
+++ b/category/systems-management/yast/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/page/5/index.html
+++ b/category/systems-management/yast/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/page/6/index.html
+++ b/category/systems-management/yast/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -1203,7 +1198,6 @@ the installation command line, it usually means that a reboot of the machine is 
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/category/systems-management/yast/page/7/index.html
+++ b/category/systems-management/yast/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/page/8/index.html
+++ b/category/systems-management/yast/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/systems-management/yast/page/9/index.html
+++ b/category/systems-management/yast/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/uncategorized/index.html
+++ b/category/uncategorized/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/uncategorized/page/2/index.html
+++ b/category/uncategorized/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/uncategorized/page/3/index.html
+++ b/category/uncategorized/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/uncategorized/page/4/index.html
+++ b/category/uncategorized/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/uncategorized/page/5/index.html
+++ b/category/uncategorized/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/uncategorized/page/6/index.html
+++ b/category/uncategorized/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/uncategorized/page/7/index.html
+++ b/category/uncategorized/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/uncategorized/page/8/index.html
+++ b/category/uncategorized/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/usability/index.html
+++ b/category/usability/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/usability/page/2/index.html
+++ b/category/usability/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/usability/page/3/index.html
+++ b/category/usability/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/usability/page/4/index.html
+++ b/category/usability/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/usability/page/5/index.html
+++ b/category/usability/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/usability/page/6/index.html
+++ b/category/usability/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/usability/page/7/index.html
+++ b/category/usability/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/usability/page/8/index.html
+++ b/category/usability/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/wiki/index.html
+++ b/category/wiki/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/category/wiki/page/2/index.html
+++ b/category/wiki/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html
+++ b/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?attachment_id=9218
+++ b/index.html?attachment_id=9218
@@ -21,15 +21,10 @@
   <meta property="og:description" content="fglrx 13.1 amd-ccc &#38; fgl_glxgears" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?attachment_id=9219
+++ b/index.html?attachment_id=9219
@@ -21,15 +21,10 @@
   <meta property="og:description" content="fglrx &#38; 3d effects kde 4.9.5 on openSUSE 12.2" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?attachment_id=9221
+++ b/index.html?attachment_id=9221
@@ -21,15 +21,10 @@
   <meta property="og:description" content="flash film ( osc13 Thessaloniki teasing )" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10
+++ b/index.html?p=10
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10001
+++ b/index.html?p=10001
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10010
+++ b/index.html?p=10010
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10026
+++ b/index.html?p=10026
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10041
+++ b/index.html?p=10041
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10057
+++ b/index.html?p=10057
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1008
+++ b/index.html?p=1008
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10083
+++ b/index.html?p=10083
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10095
+++ b/index.html?p=10095
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10114
+++ b/index.html?p=10114
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10130
+++ b/index.html?p=10130
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10133
+++ b/index.html?p=10133
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10147
+++ b/index.html?p=10147
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1015
+++ b/index.html?p=1015
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1016
+++ b/index.html?p=1016
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10161
+++ b/index.html?p=10161
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10164
+++ b/index.html?p=10164
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10174
+++ b/index.html?p=10174
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10181
+++ b/index.html?p=10181
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10203
+++ b/index.html?p=10203
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10208
+++ b/index.html?p=10208
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10230
+++ b/index.html?p=10230
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10255
+++ b/index.html?p=10255
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10275
+++ b/index.html?p=10275
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10277
+++ b/index.html?p=10277
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10304
+++ b/index.html?p=10304
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10329
+++ b/index.html?p=10329
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1033
+++ b/index.html?p=1033
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10363
+++ b/index.html?p=10363
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10367
+++ b/index.html?p=10367
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10387
+++ b/index.html?p=10387
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=104
+++ b/index.html?p=104
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10402
+++ b/index.html?p=10402
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10417
+++ b/index.html?p=10417
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10432
+++ b/index.html?p=10432
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10440
+++ b/index.html?p=10440
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10448
+++ b/index.html?p=10448
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1046
+++ b/index.html?p=1046
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10464
+++ b/index.html?p=10464
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10466
+++ b/index.html?p=10466
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10470
+++ b/index.html?p=10470
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10484
+++ b/index.html?p=10484
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10489
+++ b/index.html?p=10489
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10494
+++ b/index.html?p=10494
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=105
+++ b/index.html?p=105
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10518
+++ b/index.html?p=10518
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1052
+++ b/index.html?p=1052
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10538
+++ b/index.html?p=10538
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10557
+++ b/index.html?p=10557
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10570
+++ b/index.html?p=10570
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10582
+++ b/index.html?p=10582
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=106
+++ b/index.html?p=106
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10613
+++ b/index.html?p=10613
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10618
+++ b/index.html?p=10618
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10627
+++ b/index.html?p=10627
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10631
+++ b/index.html?p=10631
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10639
+++ b/index.html?p=10639
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1064
+++ b/index.html?p=1064
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10658
+++ b/index.html?p=10658
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1066
+++ b/index.html?p=1066
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10665
+++ b/index.html?p=10665
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10675
+++ b/index.html?p=10675
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10678
+++ b/index.html?p=10678
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10686
+++ b/index.html?p=10686
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10693
+++ b/index.html?p=10693
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=107
+++ b/index.html?p=107
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10702
+++ b/index.html?p=10702
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1071
+++ b/index.html?p=1071
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10740
+++ b/index.html?p=10740
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10757
+++ b/index.html?p=10757
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1076
+++ b/index.html?p=1076
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10762
+++ b/index.html?p=10762
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10773
+++ b/index.html?p=10773
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10776
+++ b/index.html?p=10776
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10788
+++ b/index.html?p=10788
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1079
+++ b/index.html?p=1079
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10798
+++ b/index.html?p=10798
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=108
+++ b/index.html?p=108
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10809
+++ b/index.html?p=10809
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10818
+++ b/index.html?p=10818
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1082
+++ b/index.html?p=1082
@@ -23,15 +23,10 @@
 Working together with many people from different areas of interest - but all with focus on schools and education - needs good and extensive communication to get all "on board driving in nearly one direction". The community week helped us to communicate in our IRC channel and coordinate our effords." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10840
+++ b/index.html?p=10840
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10845
+++ b/index.html?p=10845
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10850
+++ b/index.html?p=10850
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10855
+++ b/index.html?p=10855
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10857
+++ b/index.html?p=10857
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10867
+++ b/index.html?p=10867
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10872
+++ b/index.html?p=10872
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10879
+++ b/index.html?p=10879
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10906
+++ b/index.html?p=10906
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10911
+++ b/index.html?p=10911
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10924
+++ b/index.html?p=10924
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10926
+++ b/index.html?p=10926
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10928
+++ b/index.html?p=10928
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10940
+++ b/index.html?p=10940
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10943
+++ b/index.html?p=10943
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10954
+++ b/index.html?p=10954
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10968
+++ b/index.html?p=10968
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10984
+++ b/index.html?p=10984
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=10988
+++ b/index.html?p=10988
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11005
+++ b/index.html?p=11005
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11040
+++ b/index.html?p=11040
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11045
+++ b/index.html?p=11045
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11052
+++ b/index.html?p=11052
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11055
+++ b/index.html?p=11055
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11059
+++ b/index.html?p=11059
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11073
+++ b/index.html?p=11073
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11084
+++ b/index.html?p=11084
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1109
+++ b/index.html?p=1109
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11090
+++ b/index.html?p=11090
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11096
+++ b/index.html?p=11096
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11100
+++ b/index.html?p=11100
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11102
+++ b/index.html?p=11102
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11109
+++ b/index.html?p=11109
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11121
+++ b/index.html?p=11121
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1114
+++ b/index.html?p=1114
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11147
+++ b/index.html?p=11147
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11153
+++ b/index.html?p=11153
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -563,7 +558,6 @@ To find out I <a href="http://www.suse.de/~lnussel/setupgrubfornfsinstall.html">
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/comment-reply.min.js?ver=4.7.5'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/index.html?p=11175
+++ b/index.html?p=11175
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11179
+++ b/index.html?p=11179
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11182
+++ b/index.html?p=11182
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11193
+++ b/index.html?p=11193
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=112
+++ b/index.html?p=112
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11203
+++ b/index.html?p=11203
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11207
+++ b/index.html?p=11207
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11228
+++ b/index.html?p=11228
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1124
+++ b/index.html?p=1124
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11246
+++ b/index.html?p=11246
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11254
+++ b/index.html?p=11254
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11267
+++ b/index.html?p=11267
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11285
+++ b/index.html?p=11285
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11291
+++ b/index.html?p=11291
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11298
+++ b/index.html?p=11298
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11303
+++ b/index.html?p=11303
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11306
+++ b/index.html?p=11306
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11309
+++ b/index.html?p=11309
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11310
+++ b/index.html?p=11310
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11312
+++ b/index.html?p=11312
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11320
+++ b/index.html?p=11320
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11327
+++ b/index.html?p=11327
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11331
+++ b/index.html?p=11331
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11334
+++ b/index.html?p=11334
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11367
+++ b/index.html?p=11367
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11380
+++ b/index.html?p=11380
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11383
+++ b/index.html?p=11383
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1139
+++ b/index.html?p=1139
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11394
+++ b/index.html?p=11394
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11399
+++ b/index.html?p=11399
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11404
+++ b/index.html?p=11404
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11411
+++ b/index.html?p=11411
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11414
+++ b/index.html?p=11414
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1142
+++ b/index.html?p=1142
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11424
+++ b/index.html?p=11424
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11426
+++ b/index.html?p=11426
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11428
+++ b/index.html?p=11428
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11431
+++ b/index.html?p=11431
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11434
+++ b/index.html?p=11434
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11438
+++ b/index.html?p=11438
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11466
+++ b/index.html?p=11466
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11469
+++ b/index.html?p=11469
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11476
+++ b/index.html?p=11476
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11479
+++ b/index.html?p=11479
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1148
+++ b/index.html?p=1148
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11482
+++ b/index.html?p=11482
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11497
+++ b/index.html?p=11497
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11501
+++ b/index.html?p=11501
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11517
+++ b/index.html?p=11517
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1152
+++ b/index.html?p=1152
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11533
+++ b/index.html?p=11533
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11536
+++ b/index.html?p=11536
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11543
+++ b/index.html?p=11543
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1155
+++ b/index.html?p=1155
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11555
+++ b/index.html?p=11555
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11558
+++ b/index.html?p=11558
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11564
+++ b/index.html?p=11564
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11569
+++ b/index.html?p=11569
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11575
+++ b/index.html?p=11575
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11579
+++ b/index.html?p=11579
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11582
+++ b/index.html?p=11582
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11584
+++ b/index.html?p=11584
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11596
+++ b/index.html?p=11596
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11600
+++ b/index.html?p=11600
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Learning" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11601
+++ b/index.html?p=11601
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Learning" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11603
+++ b/index.html?p=11603
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Multimedia" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11604
+++ b/index.html?p=11604
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Office" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11605
+++ b/index.html?p=11605
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Graphics" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11607
+++ b/index.html?p=11607
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Development" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11608
+++ b/index.html?p=11608
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Games" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11609
+++ b/index.html?p=11609
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Mate desktop" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11624
+++ b/index.html?p=11624
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11630
+++ b/index.html?p=11630
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11642
+++ b/index.html?p=11642
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11647
+++ b/index.html?p=11647
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1165
+++ b/index.html?p=1165
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1167
+++ b/index.html?p=1167
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11671
+++ b/index.html?p=11671
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11673
+++ b/index.html?p=11673
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=117
+++ b/index.html?p=117
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11705
+++ b/index.html?p=11705
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11707
+++ b/index.html?p=11707
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11732
+++ b/index.html?p=11732
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11748
+++ b/index.html?p=11748
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1175
+++ b/index.html?p=1175
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1177
+++ b/index.html?p=1177
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11773
+++ b/index.html?p=11773
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11777
+++ b/index.html?p=11777
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11800
+++ b/index.html?p=11800
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11822
+++ b/index.html?p=11822
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1183
+++ b/index.html?p=1183
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11853
+++ b/index.html?p=11853
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11878
+++ b/index.html?p=11878
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11885
+++ b/index.html?p=11885
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11887
+++ b/index.html?p=11887
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11890
+++ b/index.html?p=11890
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11893
+++ b/index.html?p=11893
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=119
+++ b/index.html?p=119
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11920
+++ b/index.html?p=11920
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11931
+++ b/index.html?p=11931
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11935
+++ b/index.html?p=11935
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1194
+++ b/index.html?p=1194
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11959
+++ b/index.html?p=11959
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1198
+++ b/index.html?p=1198
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=11983
+++ b/index.html?p=11983
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12014
+++ b/index.html?p=12014
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12019
+++ b/index.html?p=12019
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12030
+++ b/index.html?p=12030
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12052
+++ b/index.html?p=12052
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12055
+++ b/index.html?p=12055
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1206
+++ b/index.html?p=1206
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12089
+++ b/index.html?p=12089
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12095
+++ b/index.html?p=12095
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12116
+++ b/index.html?p=12116
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12138
+++ b/index.html?p=12138
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12141
+++ b/index.html?p=12141
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12178
+++ b/index.html?p=12178
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12180
+++ b/index.html?p=12180
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1219
+++ b/index.html?p=1219
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12224
+++ b/index.html?p=12224
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12231
+++ b/index.html?p=12231
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12236
+++ b/index.html?p=12236
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12244
+++ b/index.html?p=12244
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12263
+++ b/index.html?p=12263
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1229
+++ b/index.html?p=1229
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12290
+++ b/index.html?p=12290
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12303
+++ b/index.html?p=12303
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12331
+++ b/index.html?p=12331
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12356
+++ b/index.html?p=12356
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12363
+++ b/index.html?p=12363
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1241
+++ b/index.html?p=1241
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12416
+++ b/index.html?p=12416
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1242
+++ b/index.html?p=1242
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12432
+++ b/index.html?p=12432
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12465
+++ b/index.html?p=12465
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12478
+++ b/index.html?p=12478
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12509
+++ b/index.html?p=12509
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12518
+++ b/index.html?p=12518
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12523
+++ b/index.html?p=12523
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12539
+++ b/index.html?p=12539
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1257
+++ b/index.html?p=1257
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12575
+++ b/index.html?p=12575
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12591
+++ b/index.html?p=12591
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -613,7 +608,6 @@ img.emoji {
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/comment-reply.min.js?ver=4.7.5'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/index.html?p=12616
+++ b/index.html?p=12616
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12623
+++ b/index.html?p=12623
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1266
+++ b/index.html?p=1266
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12674
+++ b/index.html?p=12674
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1268
+++ b/index.html?p=1268
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12701
+++ b/index.html?p=12701
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12705
+++ b/index.html?p=12705
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12744
+++ b/index.html?p=12744
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12747
+++ b/index.html?p=12747
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1275
+++ b/index.html?p=1275
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12762
+++ b/index.html?p=12762
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12784
+++ b/index.html?p=12784
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12786
+++ b/index.html?p=12786
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1280
+++ b/index.html?p=1280
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12806
+++ b/index.html?p=12806
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1282
+++ b/index.html?p=1282
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12839
+++ b/index.html?p=12839
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1285
+++ b/index.html?p=1285
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1287
+++ b/index.html?p=1287
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12886
+++ b/index.html?p=12886
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=129
+++ b/index.html?p=129
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12910
+++ b/index.html?p=12910
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12928
+++ b/index.html?p=12928
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1294
+++ b/index.html?p=1294
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12957
+++ b/index.html?p=12957
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=12985
+++ b/index.html?p=12985
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1299
+++ b/index.html?p=1299
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13
+++ b/index.html?p=13
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=130
+++ b/index.html?p=130
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1303
+++ b/index.html?p=1303
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13035
+++ b/index.html?p=13035
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13054
+++ b/index.html?p=13054
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1307
+++ b/index.html?p=1307
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13090
+++ b/index.html?p=13090
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=131
+++ b/index.html?p=131
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13127
+++ b/index.html?p=13127
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13138
+++ b/index.html?p=13138
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1315
+++ b/index.html?p=1315
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13188
+++ b/index.html?p=13188
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=132
+++ b/index.html?p=132
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13201
+++ b/index.html?p=13201
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13239
+++ b/index.html?p=13239
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13248
+++ b/index.html?p=13248
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13278
+++ b/index.html?p=13278
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13291
+++ b/index.html?p=13291
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13325
+++ b/index.html?p=13325
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13344
+++ b/index.html?p=13344
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13381
+++ b/index.html?p=13381
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=134
+++ b/index.html?p=134
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13401
+++ b/index.html?p=13401
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13402
+++ b/index.html?p=13402
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13451
+++ b/index.html?p=13451
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13462
+++ b/index.html?p=13462
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1348
+++ b/index.html?p=1348
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13484
+++ b/index.html?p=13484
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=135
+++ b/index.html?p=135
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13513
+++ b/index.html?p=13513
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13522
+++ b/index.html?p=13522
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1353
+++ b/index.html?p=1353
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1355
+++ b/index.html?p=1355
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13553
+++ b/index.html?p=13553
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13575
+++ b/index.html?p=13575
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13596
+++ b/index.html?p=13596
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=136
+++ b/index.html?p=136
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13625
+++ b/index.html?p=13625
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13657
+++ b/index.html?p=13657
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13681
+++ b/index.html?p=13681
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=137
+++ b/index.html?p=137
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13704
+++ b/index.html?p=13704
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13709
+++ b/index.html?p=13709
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13716
+++ b/index.html?p=13716
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1373
+++ b/index.html?p=1373
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13736
+++ b/index.html?p=13736
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13757
+++ b/index.html?p=13757
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1377
+++ b/index.html?p=1377
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13790
+++ b/index.html?p=13790
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=138
+++ b/index.html?p=138
@@ -21,15 +21,10 @@
   <meta property="og:description" content="You see it every day, you normally don't think about it, but it is nevertheless important: fonts." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13814
+++ b/index.html?p=13814
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13843
+++ b/index.html?p=13843
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1385
+++ b/index.html?p=1385
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1388
+++ b/index.html?p=1388
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13895
+++ b/index.html?p=13895
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13914
+++ b/index.html?p=13914
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1392
+++ b/index.html?p=1392
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13945
+++ b/index.html?p=13945
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13955
+++ b/index.html?p=13955
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13968
+++ b/index.html?p=13968
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1398
+++ b/index.html?p=1398
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=13988
+++ b/index.html?p=13988
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14
+++ b/index.html?p=14
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=140
+++ b/index.html?p=140
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14003
+++ b/index.html?p=14003
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1401
+++ b/index.html?p=1401
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14032
+++ b/index.html?p=14032
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14038
+++ b/index.html?p=14038
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14054
+++ b/index.html?p=14054
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14083
+++ b/index.html?p=14083
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1409
+++ b/index.html?p=1409
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=141
+++ b/index.html?p=141
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14109
+++ b/index.html?p=14109
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14127
+++ b/index.html?p=14127
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14141
+++ b/index.html?p=14141
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14173
+++ b/index.html?p=14173
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14176
+++ b/index.html?p=14176
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1418
+++ b/index.html?p=1418
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14198
+++ b/index.html?p=14198
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1421
+++ b/index.html?p=1421
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14231
+++ b/index.html?p=14231
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14236
+++ b/index.html?p=14236
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1427
+++ b/index.html?p=1427
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14289
+++ b/index.html?p=14289
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=143
+++ b/index.html?p=143
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14311
+++ b/index.html?p=14311
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14347
+++ b/index.html?p=14347
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=14350
+++ b/index.html?p=14350
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1438
+++ b/index.html?p=1438
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=144
+++ b/index.html?p=144
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1443
+++ b/index.html?p=1443
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1446
+++ b/index.html?p=1446
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=145
+++ b/index.html?p=145
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1453
+++ b/index.html?p=1453
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1459
+++ b/index.html?p=1459
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=146
+++ b/index.html?p=146
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=147
+++ b/index.html?p=147
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1471
+++ b/index.html?p=1471
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1475
+++ b/index.html?p=1475
@@ -21,15 +21,10 @@
   <meta property="og:description" content="To make suspend to disk work with an encrypted root file system and swap on lvm on luks, add "luks" to the "#%depends:" line in /lib/mkinitrd/scripts/boot-lvm2.sh and recreate the initial ramdisk." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1479
+++ b/index.html?p=1479
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=148
+++ b/index.html?p=148
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1487
+++ b/index.html?p=1487
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=15
+++ b/index.html?p=15
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=150
+++ b/index.html?p=150
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1503
+++ b/index.html?p=1503
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=151
+++ b/index.html?p=151
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=152
+++ b/index.html?p=152
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1521
+++ b/index.html?p=1521
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1524
+++ b/index.html?p=1524
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=153
+++ b/index.html?p=153
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1530
+++ b/index.html?p=1530
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1532
+++ b/index.html?p=1532
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1534
+++ b/index.html?p=1534
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1536
+++ b/index.html?p=1536
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=154
+++ b/index.html?p=154
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1545
+++ b/index.html?p=1545
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=155
+++ b/index.html?p=155
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1558
+++ b/index.html?p=1558
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=156
+++ b/index.html?p=156
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=157
+++ b/index.html?p=157
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1572
+++ b/index.html?p=1572
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1577
+++ b/index.html?p=1577
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=158
+++ b/index.html?p=158
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1584
+++ b/index.html?p=1584
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=159
+++ b/index.html?p=159
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1591
+++ b/index.html?p=1591
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=16
+++ b/index.html?p=16
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=161
+++ b/index.html?p=161
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1610
+++ b/index.html?p=1610
@@ -21,15 +21,10 @@
   <meta property="og:description" content="The hackweek project I worked to create a live graphing utility that displays I/O of processes. Screen-shots, RPM download link, project homepage link,..." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=162
+++ b/index.html?p=162
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=163
+++ b/index.html?p=163
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=164
+++ b/index.html?p=164
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1648
+++ b/index.html?p=1648
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1651
+++ b/index.html?p=1651
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=166
+++ b/index.html?p=166
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1666
+++ b/index.html?p=1666
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=167
+++ b/index.html?p=167
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1671
+++ b/index.html?p=1671
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=168
+++ b/index.html?p=168
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1685
+++ b/index.html?p=1685
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1690
+++ b/index.html?p=1690
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1709
+++ b/index.html?p=1709
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=171
+++ b/index.html?p=171
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=172
+++ b/index.html?p=172
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1728
+++ b/index.html?p=1728
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=174
+++ b/index.html?p=174
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1744
+++ b/index.html?p=1744
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=175
+++ b/index.html?p=175
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1759
+++ b/index.html?p=1759
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=176
+++ b/index.html?p=176
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1763
+++ b/index.html?p=1763
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1766
+++ b/index.html?p=1766
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=177
+++ b/index.html?p=177
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1775
+++ b/index.html?p=1775
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=178
+++ b/index.html?p=178
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=179
+++ b/index.html?p=179
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1796
+++ b/index.html?p=1796
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=18
+++ b/index.html?p=18
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=180
+++ b/index.html?p=180
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1803
+++ b/index.html?p=1803
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1824
+++ b/index.html?p=1824
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=183
+++ b/index.html?p=183
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1831
+++ b/index.html?p=1831
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1836
+++ b/index.html?p=1836
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=184
+++ b/index.html?p=184
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1857
+++ b/index.html?p=1857
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1865
+++ b/index.html?p=1865
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1868
+++ b/index.html?p=1868
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=187
+++ b/index.html?p=187
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1872
+++ b/index.html?p=1872
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=188
+++ b/index.html?p=188
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1899
+++ b/index.html?p=1899
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=19
+++ b/index.html?p=19
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1908
+++ b/index.html?p=1908
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1919
+++ b/index.html?p=1919
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1933
+++ b/index.html?p=1933
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1938
+++ b/index.html?p=1938
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=195
+++ b/index.html?p=195
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1951
+++ b/index.html?p=1951
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1960
+++ b/index.html?p=1960
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1962
+++ b/index.html?p=1962
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1968
+++ b/index.html?p=1968
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1970
+++ b/index.html?p=1970
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=1979
+++ b/index.html?p=1979
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=198
+++ b/index.html?p=198
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=199
+++ b/index.html?p=199
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2000
+++ b/index.html?p=2000
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2003
+++ b/index.html?p=2003
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2013
+++ b/index.html?p=2013
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2017
+++ b/index.html?p=2017
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2022
+++ b/index.html?p=2022
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2025
+++ b/index.html?p=2025
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2033
+++ b/index.html?p=2033
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=204
+++ b/index.html?p=204
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2040
+++ b/index.html?p=2040
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2048
+++ b/index.html?p=2048
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2054
+++ b/index.html?p=2054
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=206
+++ b/index.html?p=206
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2067
+++ b/index.html?p=2067
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=207
+++ b/index.html?p=207
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2079
+++ b/index.html?p=2079
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2084
+++ b/index.html?p=2084
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2089
+++ b/index.html?p=2089
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=209
+++ b/index.html?p=209
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2091
+++ b/index.html?p=2091
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2095
+++ b/index.html?p=2095
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2097
+++ b/index.html?p=2097
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=210
+++ b/index.html?p=210
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2100
+++ b/index.html?p=2100
@@ -21,15 +21,10 @@
   <meta property="og:description" content="LXDE" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2103
+++ b/index.html?p=2103
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=211
+++ b/index.html?p=211
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2111
+++ b/index.html?p=2111
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2121
+++ b/index.html?p=2121
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2129
+++ b/index.html?p=2129
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2166
+++ b/index.html?p=2166
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2170
+++ b/index.html?p=2170
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=22
+++ b/index.html?p=22
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2218
+++ b/index.html?p=2218
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=222
+++ b/index.html?p=222
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=223
+++ b/index.html?p=223
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2232
+++ b/index.html?p=2232
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=224
+++ b/index.html?p=224
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2249
+++ b/index.html?p=2249
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=225
+++ b/index.html?p=225
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2272
+++ b/index.html?p=2272
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2274
+++ b/index.html?p=2274
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=228
+++ b/index.html?p=228
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2280
+++ b/index.html?p=2280
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=229
+++ b/index.html?p=229
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=23
+++ b/index.html?p=23
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2306
+++ b/index.html?p=2306
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2317
+++ b/index.html?p=2317
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=232
+++ b/index.html?p=232
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2333
+++ b/index.html?p=2333
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2339
+++ b/index.html?p=2339
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2345
+++ b/index.html?p=2345
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2351
+++ b/index.html?p=2351
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2356
+++ b/index.html?p=2356
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2358
+++ b/index.html?p=2358
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2368
+++ b/index.html?p=2368
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=237
+++ b/index.html?p=237
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2373
+++ b/index.html?p=2373
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=238
+++ b/index.html?p=238
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2380
+++ b/index.html?p=2380
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2385
+++ b/index.html?p=2385
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=239
+++ b/index.html?p=239
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=24
+++ b/index.html?p=24
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=240
+++ b/index.html?p=240
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2402
+++ b/index.html?p=2402
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2409
+++ b/index.html?p=2409
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=241
+++ b/index.html?p=241
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2425
+++ b/index.html?p=2425
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=243
+++ b/index.html?p=243
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2430
+++ b/index.html?p=2430
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2434
+++ b/index.html?p=2434
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=244
+++ b/index.html?p=244
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2440
+++ b/index.html?p=2440
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2452
+++ b/index.html?p=2452
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=246
+++ b/index.html?p=246
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2462
+++ b/index.html?p=2462
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2470
+++ b/index.html?p=2470
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2475
+++ b/index.html?p=2475
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=248
+++ b/index.html?p=248
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=249
+++ b/index.html?p=249
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2490
+++ b/index.html?p=2490
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2495
+++ b/index.html?p=2495
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=25
+++ b/index.html?p=25
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=250
+++ b/index.html?p=250
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2507
+++ b/index.html?p=2507
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2511
+++ b/index.html?p=2511
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2526
+++ b/index.html?p=2526
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=253
+++ b/index.html?p=253
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=254
+++ b/index.html?p=254
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2543
+++ b/index.html?p=2543
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=255
+++ b/index.html?p=255
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2552
+++ b/index.html?p=2552
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2559
+++ b/index.html?p=2559
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2568
+++ b/index.html?p=2568
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=258
+++ b/index.html?p=258
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2589
+++ b/index.html?p=2589
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=259
+++ b/index.html?p=259
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2595
+++ b/index.html?p=2595
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=26
+++ b/index.html?p=26
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=260
+++ b/index.html?p=260
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2632
+++ b/index.html?p=2632
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=265
+++ b/index.html?p=265
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2676
+++ b/index.html?p=2676
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=268
+++ b/index.html?p=268
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2681
+++ b/index.html?p=2681
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2687
+++ b/index.html?p=2687
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=269
+++ b/index.html?p=269
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2697
+++ b/index.html?p=2697
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=270
+++ b/index.html?p=270
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2700
+++ b/index.html?p=2700
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2719
+++ b/index.html?p=2719
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=272
+++ b/index.html?p=272
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2724
+++ b/index.html?p=2724
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=273
+++ b/index.html?p=273
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=274
+++ b/index.html?p=274
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=275
+++ b/index.html?p=275
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=276
+++ b/index.html?p=276
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2767
+++ b/index.html?p=2767
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=278
+++ b/index.html?p=278
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2782
+++ b/index.html?p=2782
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=279
+++ b/index.html?p=279
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=28
+++ b/index.html?p=28
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=280
+++ b/index.html?p=280
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2800
+++ b/index.html?p=2800
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2811
+++ b/index.html?p=2811
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2819
+++ b/index.html?p=2819
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2827
+++ b/index.html?p=2827
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=284
+++ b/index.html?p=284
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=286
+++ b/index.html?p=286
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2867
+++ b/index.html?p=2867
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=287
+++ b/index.html?p=287
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2871
+++ b/index.html?p=2871
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=288
+++ b/index.html?p=288
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2881
+++ b/index.html?p=2881
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2884
+++ b/index.html?p=2884
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=289
+++ b/index.html?p=289
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2899
+++ b/index.html?p=2899
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=29
+++ b/index.html?p=29
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2903
+++ b/index.html?p=2903
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2909
+++ b/index.html?p=2909
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=291
+++ b/index.html?p=291
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2916
+++ b/index.html?p=2916
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2927
+++ b/index.html?p=2927
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2931
+++ b/index.html?p=2931
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=294
+++ b/index.html?p=294
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2940
+++ b/index.html?p=2940
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2952
+++ b/index.html?p=2952
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2961
+++ b/index.html?p=2961
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2968
+++ b/index.html?p=2968
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=297
+++ b/index.html?p=297
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2970
+++ b/index.html?p=2970
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2975
+++ b/index.html?p=2975
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2982
+++ b/index.html?p=2982
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=2987
+++ b/index.html?p=2987
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=299
+++ b/index.html?p=299
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=30
+++ b/index.html?p=30
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=300
+++ b/index.html?p=300
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3002
+++ b/index.html?p=3002
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=301
+++ b/index.html?p=301
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=302
+++ b/index.html?p=302
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=303
+++ b/index.html?p=303
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3039
+++ b/index.html?p=3039
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=305
+++ b/index.html?p=305
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=306
+++ b/index.html?p=306
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3073
+++ b/index.html?p=3073
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=31
+++ b/index.html?p=31
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=312
+++ b/index.html?p=312
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=313
+++ b/index.html?p=313
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3132
+++ b/index.html?p=3132
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3138
+++ b/index.html?p=3138
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=314
+++ b/index.html?p=314
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3146
+++ b/index.html?p=3146
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=315
+++ b/index.html?p=315
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3152
+++ b/index.html?p=3152
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3159
+++ b/index.html?p=3159
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=317
+++ b/index.html?p=317
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=318
+++ b/index.html?p=318
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3182
+++ b/index.html?p=3182
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3192
+++ b/index.html?p=3192
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3197
+++ b/index.html?p=3197
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=32
+++ b/index.html?p=32
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3203
+++ b/index.html?p=3203
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3205
+++ b/index.html?p=3205
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3210
+++ b/index.html?p=3210
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3219
+++ b/index.html?p=3219
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=323
+++ b/index.html?p=323
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3232
+++ b/index.html?p=3232
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3239
+++ b/index.html?p=3239
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=324
+++ b/index.html?p=324
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3248
+++ b/index.html?p=3248
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3253
+++ b/index.html?p=3253
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3258
+++ b/index.html?p=3258
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=326
+++ b/index.html?p=326
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=327
+++ b/index.html?p=327
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3275
+++ b/index.html?p=3275
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Lots of FLOSS people gathered at the past FOSDEM 2010" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3276
+++ b/index.html?p=3276
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Lots of attention gathered the openSUSE 11.2 demo at the openSUSE booth at FOSDEM 2010" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=329
+++ b/index.html?p=329
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3292
+++ b/index.html?p=3292
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3295
+++ b/index.html?p=3295
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=33
+++ b/index.html?p=33
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=330
+++ b/index.html?p=330
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=331
+++ b/index.html?p=331
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=332
+++ b/index.html?p=332
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3329
+++ b/index.html?p=3329
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=333
+++ b/index.html?p=333
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3333
+++ b/index.html?p=3333
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3338
+++ b/index.html?p=3338
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3344
+++ b/index.html?p=3344
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3348
+++ b/index.html?p=3348
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=335
+++ b/index.html?p=335
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3354
+++ b/index.html?p=3354
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=336
+++ b/index.html?p=336
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=337
+++ b/index.html?p=337
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3371
+++ b/index.html?p=3371
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3374
+++ b/index.html?p=3374
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3379
+++ b/index.html?p=3379
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=338
+++ b/index.html?p=338
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3399
+++ b/index.html?p=3399
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=34
+++ b/index.html?p=34
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=340
+++ b/index.html?p=340
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3408
+++ b/index.html?p=3408
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3411
+++ b/index.html?p=3411
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3418
+++ b/index.html?p=3418
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3421
+++ b/index.html?p=3421
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3429
+++ b/index.html?p=3429
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3438
+++ b/index.html?p=3438
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3441
+++ b/index.html?p=3441
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3449
+++ b/index.html?p=3449
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=345
+++ b/index.html?p=345
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3454
+++ b/index.html?p=3454
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3457
+++ b/index.html?p=3457
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=346
+++ b/index.html?p=346
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3460
+++ b/index.html?p=3460
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=347
+++ b/index.html?p=347
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=348
+++ b/index.html?p=348
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3490
+++ b/index.html?p=3490
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=35
+++ b/index.html?p=35
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3500
+++ b/index.html?p=3500
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3505
+++ b/index.html?p=3505
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3516
+++ b/index.html?p=3516
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3528
+++ b/index.html?p=3528
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=353
+++ b/index.html?p=353
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3536
+++ b/index.html?p=3536
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=354
+++ b/index.html?p=354
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=355
+++ b/index.html?p=355
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=357
+++ b/index.html?p=357
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=359
+++ b/index.html?p=359
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3595
+++ b/index.html?p=3595
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3599
+++ b/index.html?p=3599
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=36
+++ b/index.html?p=36
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=360
+++ b/index.html?p=360
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=361
+++ b/index.html?p=361
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3611
+++ b/index.html?p=3611
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3615
+++ b/index.html?p=3615
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3619
+++ b/index.html?p=3619
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3625
+++ b/index.html?p=3625
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3638
+++ b/index.html?p=3638
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3640
+++ b/index.html?p=3640
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3649
+++ b/index.html?p=3649
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=366
+++ b/index.html?p=366
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3663
+++ b/index.html?p=3663
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3667
+++ b/index.html?p=3667
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3676
+++ b/index.html?p=3676
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=368
+++ b/index.html?p=368
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=369
+++ b/index.html?p=369
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3696
+++ b/index.html?p=3696
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3697
+++ b/index.html?p=3697
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3698
+++ b/index.html?p=3698
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3699
+++ b/index.html?p=3699
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=37
+++ b/index.html?p=37
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=370
+++ b/index.html?p=370
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3700
+++ b/index.html?p=3700
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3701
+++ b/index.html?p=3701
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3702
+++ b/index.html?p=3702
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3703
+++ b/index.html?p=3703
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3704
+++ b/index.html?p=3704
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3706
+++ b/index.html?p=3706
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=371
+++ b/index.html?p=371
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3711
+++ b/index.html?p=3711
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3715
+++ b/index.html?p=3715
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3727
+++ b/index.html?p=3727
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=373
+++ b/index.html?p=373
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3737
+++ b/index.html?p=3737
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3750
+++ b/index.html?p=3750
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3754
+++ b/index.html?p=3754
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3762
+++ b/index.html?p=3762
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3765
+++ b/index.html?p=3765
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3778
+++ b/index.html?p=3778
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3786
+++ b/index.html?p=3786
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3788
+++ b/index.html?p=3788
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3791
+++ b/index.html?p=3791
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3799
+++ b/index.html?p=3799
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=38
+++ b/index.html?p=38
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3804
+++ b/index.html?p=3804
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3814
+++ b/index.html?p=3814
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3819
+++ b/index.html?p=3819
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3824
+++ b/index.html?p=3824
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3826
+++ b/index.html?p=3826
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3831
+++ b/index.html?p=3831
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3835
+++ b/index.html?p=3835
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3836
+++ b/index.html?p=3836
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3837
+++ b/index.html?p=3837
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3838
+++ b/index.html?p=3838
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3839
+++ b/index.html?p=3839
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3840
+++ b/index.html?p=3840
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3841
+++ b/index.html?p=3841
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3842
+++ b/index.html?p=3842
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3843
+++ b/index.html?p=3843
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3844
+++ b/index.html?p=3844
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3855
+++ b/index.html?p=3855
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3856
+++ b/index.html?p=3856
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3859
+++ b/index.html?p=3859
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=388
+++ b/index.html?p=388
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3880
+++ b/index.html?p=3880
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=389
+++ b/index.html?p=389
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=39
+++ b/index.html?p=39
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3902
+++ b/index.html?p=3902
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=391
+++ b/index.html?p=391
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=392
+++ b/index.html?p=392
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=393
+++ b/index.html?p=393
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3939
+++ b/index.html?p=3939
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3959
+++ b/index.html?p=3959
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=396
+++ b/index.html?p=396
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3965
+++ b/index.html?p=3965
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=3969
+++ b/index.html?p=3969
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=40
+++ b/index.html?p=40
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4005
+++ b/index.html?p=4005
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4009
+++ b/index.html?p=4009
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4028
+++ b/index.html?p=4028
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4033
+++ b/index.html?p=4033
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=404
+++ b/index.html?p=404
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4040
+++ b/index.html?p=4040
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4044
+++ b/index.html?p=4044
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4049
+++ b/index.html?p=4049
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=405
+++ b/index.html?p=405
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4052
+++ b/index.html?p=4052
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4058
+++ b/index.html?p=4058
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=407
+++ b/index.html?p=407
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4072
+++ b/index.html?p=4072
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4079
+++ b/index.html?p=4079
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=408
+++ b/index.html?p=408
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4082
+++ b/index.html?p=4082
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Testing is an important task. But testing daily openSUSE-Factory snapshots would mean testing the same things every day. This would be pretty tiresome to people." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4089
+++ b/index.html?p=4089
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4094
+++ b/index.html?p=4094
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=410
+++ b/index.html?p=410
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4101
+++ b/index.html?p=4101
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=412
+++ b/index.html?p=412
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4158
+++ b/index.html?p=4158
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=416
+++ b/index.html?p=416
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4161
+++ b/index.html?p=4161
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=418
+++ b/index.html?p=418
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=419
+++ b/index.html?p=419
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4195
+++ b/index.html?p=4195
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=42
+++ b/index.html?p=42
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4210
+++ b/index.html?p=4210
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4214
+++ b/index.html?p=4214
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=422
+++ b/index.html?p=422
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4220
+++ b/index.html?p=4220
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4224
+++ b/index.html?p=4224
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=423
+++ b/index.html?p=423
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=424
+++ b/index.html?p=424
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4250
+++ b/index.html?p=4250
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4255
+++ b/index.html?p=4255
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4257
+++ b/index.html?p=4257
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4262
+++ b/index.html?p=4262
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4263
+++ b/index.html?p=4263
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4265
+++ b/index.html?p=4265
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4276
+++ b/index.html?p=4276
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=429
+++ b/index.html?p=429
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4291
+++ b/index.html?p=4291
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=43
+++ b/index.html?p=43
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=430
+++ b/index.html?p=430
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4302
+++ b/index.html?p=4302
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4305
+++ b/index.html?p=4305
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=431
+++ b/index.html?p=431
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4310
+++ b/index.html?p=4310
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=432
+++ b/index.html?p=432
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4323
+++ b/index.html?p=4323
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4326
+++ b/index.html?p=4326
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4339
+++ b/index.html?p=4339
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4363
+++ b/index.html?p=4363
@@ -22,15 +22,10 @@
 Ubuntu is still ahead of openSUSE in some regards of quality. There are things we can learn from them..." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4370
+++ b/index.html?p=4370
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4376
+++ b/index.html?p=4376
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4394
+++ b/index.html?p=4394
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4400
+++ b/index.html?p=4400
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4402
+++ b/index.html?p=4402
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4406
+++ b/index.html?p=4406
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4447
+++ b/index.html?p=4447
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=446
+++ b/index.html?p=446
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4462
+++ b/index.html?p=4462
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4470
+++ b/index.html?p=4470
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4473
+++ b/index.html?p=4473
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4476
+++ b/index.html?p=4476
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=449
+++ b/index.html?p=449
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4491
+++ b/index.html?p=4491
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4495
+++ b/index.html?p=4495
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4509
+++ b/index.html?p=4509
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4511
+++ b/index.html?p=4511
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4514
+++ b/index.html?p=4514
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4532
+++ b/index.html?p=4532
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4535
+++ b/index.html?p=4535
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4538
+++ b/index.html?p=4538
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4542
+++ b/index.html?p=4542
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4547
+++ b/index.html?p=4547
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4554
+++ b/index.html?p=4554
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4562
+++ b/index.html?p=4562
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4573
+++ b/index.html?p=4573
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4584
+++ b/index.html?p=4584
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4587
+++ b/index.html?p=4587
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4590
+++ b/index.html?p=4590
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4591
+++ b/index.html?p=4591
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4592
+++ b/index.html?p=4592
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4593
+++ b/index.html?p=4593
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4594
+++ b/index.html?p=4594
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4667
+++ b/index.html?p=4667
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4673
+++ b/index.html?p=4673
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=47
+++ b/index.html?p=47
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4701
+++ b/index.html?p=4701
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4708
+++ b/index.html?p=4708
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=471
+++ b/index.html?p=471
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4734
+++ b/index.html?p=4734
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4739
+++ b/index.html?p=4739
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4744
+++ b/index.html?p=4744
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4748
+++ b/index.html?p=4748
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4771
+++ b/index.html?p=4771
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4774
+++ b/index.html?p=4774
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4782
+++ b/index.html?p=4782
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4785
+++ b/index.html?p=4785
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4797
+++ b/index.html?p=4797
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=48
+++ b/index.html?p=48
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4801
+++ b/index.html?p=4801
@@ -21,15 +21,10 @@
   <meta property="og:description" content="I have started maintaining three packages, namely Texmaker, TeXworks and Rubber, in the Publishing repository. These applications make working with and compiling latex documents user friendly and painless." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4850
+++ b/index.html?p=4850
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4860
+++ b/index.html?p=4860
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4865
+++ b/index.html?p=4865
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4876
+++ b/index.html?p=4876
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=49
+++ b/index.html?p=49
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4900
+++ b/index.html?p=4900
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4910
+++ b/index.html?p=4910
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4918
+++ b/index.html?p=4918
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4927
+++ b/index.html?p=4927
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=4936
+++ b/index.html?p=4936
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=497
+++ b/index.html?p=497
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5
+++ b/index.html?p=5
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5008
+++ b/index.html?p=5008
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5032
+++ b/index.html?p=5032
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5034
+++ b/index.html?p=5034
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5037
+++ b/index.html?p=5037
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5048
+++ b/index.html?p=5048
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=505
+++ b/index.html?p=505
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=51
+++ b/index.html?p=51
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5104
+++ b/index.html?p=5104
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5109
+++ b/index.html?p=5109
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5115
+++ b/index.html?p=5115
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5121
+++ b/index.html?p=5121
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5132
+++ b/index.html?p=5132
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=516
+++ b/index.html?p=516
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5165
+++ b/index.html?p=5165
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5176
+++ b/index.html?p=5176
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=518
+++ b/index.html?p=518
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=519
+++ b/index.html?p=519
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5197
+++ b/index.html?p=5197
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=52
+++ b/index.html?p=52
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Maybe you know this problem: You have a couple of XML files and you need a specific information. Probably everybody would think of grep or similar tools first. But maybe your query is a bit more complicated than just a simple piece of text. What do do?" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5202
+++ b/index.html?p=5202
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5207
+++ b/index.html?p=5207
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5215
+++ b/index.html?p=5215
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5227
+++ b/index.html?p=5227
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5229
+++ b/index.html?p=5229
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5255
+++ b/index.html?p=5255
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5270
+++ b/index.html?p=5270
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5282
+++ b/index.html?p=5282
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5284
+++ b/index.html?p=5284
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=53
+++ b/index.html?p=53
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5304
+++ b/index.html?p=5304
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5320
+++ b/index.html?p=5320
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5333
+++ b/index.html?p=5333
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5350
+++ b/index.html?p=5350
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5382
+++ b/index.html?p=5382
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5393
+++ b/index.html?p=5393
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5397
+++ b/index.html?p=5397
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5399
+++ b/index.html?p=5399
@@ -22,15 +22,10 @@
 I have 2 Intel Atom's running for my mail and web servers and I was quite happy with their performances, (by the way I am still happy). Hence I decided to ride the change train and bought the Intel D510 board" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=54
+++ b/index.html?p=54
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5406
+++ b/index.html?p=5406
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5419
+++ b/index.html?p=5419
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5432
+++ b/index.html?p=5432
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=544
+++ b/index.html?p=544
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5441
+++ b/index.html?p=5441
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5474
+++ b/index.html?p=5474
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5482
+++ b/index.html?p=5482
@@ -21,15 +21,10 @@
   <meta property="og:description" content="A matryoshka doll, also known as a Russian nesting doll or a babushka doll, is a set of dolls of decreasing sizes placed one inside the other. Virtualization is a concept similar to the Matryoshka analogy. There is another system running inside the host machine. So it is box in a box. Each performs and executes exactly like a stand-alone server; a container can be rebooted independently and have root access, users, IP addresses, memory, processes, files, applications, system libraries and configuration files." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5504
+++ b/index.html?p=5504
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=551
+++ b/index.html?p=551
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5511
+++ b/index.html?p=5511
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5517
+++ b/index.html?p=5517
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5542
+++ b/index.html?p=5542
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5550
+++ b/index.html?p=5550
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5562
+++ b/index.html?p=5562
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5568
+++ b/index.html?p=5568
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5576
+++ b/index.html?p=5576
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=560
+++ b/index.html?p=560
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5623
+++ b/index.html?p=5623
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5636
+++ b/index.html?p=5636
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5652
+++ b/index.html?p=5652
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5669
+++ b/index.html?p=5669
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=57
+++ b/index.html?p=57
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=570
+++ b/index.html?p=570
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5726
+++ b/index.html?p=5726
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5730
+++ b/index.html?p=5730
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5741
+++ b/index.html?p=5741
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5744
+++ b/index.html?p=5744
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5746
+++ b/index.html?p=5746
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5747
+++ b/index.html?p=5747
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5748
+++ b/index.html?p=5748
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5749
+++ b/index.html?p=5749
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=575
+++ b/index.html?p=575
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5750
+++ b/index.html?p=5750
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5751
+++ b/index.html?p=5751
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5752
+++ b/index.html?p=5752
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5753
+++ b/index.html?p=5753
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5754
+++ b/index.html?p=5754
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5759
+++ b/index.html?p=5759
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5760
+++ b/index.html?p=5760
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5761
+++ b/index.html?p=5761
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5764
+++ b/index.html?p=5764
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5765
+++ b/index.html?p=5765
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5766
+++ b/index.html?p=5766
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5767
+++ b/index.html?p=5767
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5768
+++ b/index.html?p=5768
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=577
+++ b/index.html?p=577
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5772
+++ b/index.html?p=5772
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5780
+++ b/index.html?p=5780
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=584
+++ b/index.html?p=584
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5852
+++ b/index.html?p=5852
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5855
+++ b/index.html?p=5855
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5867
+++ b/index.html?p=5867
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5874
+++ b/index.html?p=5874
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5883
+++ b/index.html?p=5883
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5884
+++ b/index.html?p=5884
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5893
+++ b/index.html?p=5893
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=59
+++ b/index.html?p=59
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5908
+++ b/index.html?p=5908
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=591
+++ b/index.html?p=591
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5912
+++ b/index.html?p=5912
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5919
+++ b/index.html?p=5919
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5929
+++ b/index.html?p=5929
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5943
+++ b/index.html?p=5943
@@ -21,15 +21,10 @@
   <meta property="og:description" content="There is something new that is better than Factory and Milestones in some regards: factory-tested which has a known minimum quality and frequent releases." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5971
+++ b/index.html?p=5971
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5981
+++ b/index.html?p=5981
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=5992
+++ b/index.html?p=5992
@@ -23,15 +23,10 @@
 The event will take place in the city of Aveiro (Silver Coast, Portugal). The Dinner will be at 21:00 in the Pizzarte (an Italian Restaurant, which also has vegetarian service). The meet place is also Pizzarte at 20:30. There are no reservations required and the event will be on a non-smokers area." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6
+++ b/index.html?p=6
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6002
+++ b/index.html?p=6002
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=603
+++ b/index.html?p=603
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6084
+++ b/index.html?p=6084
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6087
+++ b/index.html?p=6087
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6091
+++ b/index.html?p=6091
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6103
+++ b/index.html?p=6103
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6129
+++ b/index.html?p=6129
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6132
+++ b/index.html?p=6132
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6140
+++ b/index.html?p=6140
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6145
+++ b/index.html?p=6145
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6149
+++ b/index.html?p=6149
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6153
+++ b/index.html?p=6153
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=616
+++ b/index.html?p=616
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6164
+++ b/index.html?p=6164
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6170
+++ b/index.html?p=6170
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6185
+++ b/index.html?p=6185
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=62
+++ b/index.html?p=62
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=620
+++ b/index.html?p=620
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6200
+++ b/index.html?p=6200
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6202
+++ b/index.html?p=6202
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6208
+++ b/index.html?p=6208
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6214
+++ b/index.html?p=6214
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6217
+++ b/index.html?p=6217
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6225
+++ b/index.html?p=6225
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6228
+++ b/index.html?p=6228
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6257
+++ b/index.html?p=6257
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6268
+++ b/index.html?p=6268
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=628
+++ b/index.html?p=628
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6286
+++ b/index.html?p=6286
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6288
+++ b/index.html?p=6288
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6291
+++ b/index.html?p=6291
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6292
+++ b/index.html?p=6292
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6293
+++ b/index.html?p=6293
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6294
+++ b/index.html?p=6294
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6297
+++ b/index.html?p=6297
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6298
+++ b/index.html?p=6298
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6299
+++ b/index.html?p=6299
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=63
+++ b/index.html?p=63
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6302
+++ b/index.html?p=6302
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6303
+++ b/index.html?p=6303
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6304
+++ b/index.html?p=6304
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6314
+++ b/index.html?p=6314
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6327
+++ b/index.html?p=6327
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=634
+++ b/index.html?p=634
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6340
+++ b/index.html?p=6340
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6349
+++ b/index.html?p=6349
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6358
+++ b/index.html?p=6358
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6371
+++ b/index.html?p=6371
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6375
+++ b/index.html?p=6375
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6380
+++ b/index.html?p=6380
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6383
+++ b/index.html?p=6383
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6392
+++ b/index.html?p=6392
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=64
+++ b/index.html?p=64
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6418
+++ b/index.html?p=6418
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6434
+++ b/index.html?p=6434
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6443
+++ b/index.html?p=6443
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6461
+++ b/index.html?p=6461
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6466
+++ b/index.html?p=6466
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=647
+++ b/index.html?p=647
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6475
+++ b/index.html?p=6475
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6481
+++ b/index.html?p=6481
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6497
+++ b/index.html?p=6497
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=65
+++ b/index.html?p=65
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=650
+++ b/index.html?p=650
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6501
+++ b/index.html?p=6501
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6514
+++ b/index.html?p=6514
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6521
+++ b/index.html?p=6521
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=653
+++ b/index.html?p=653
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6536
+++ b/index.html?p=6536
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6538
+++ b/index.html?p=6538
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6546
+++ b/index.html?p=6546
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6555
+++ b/index.html?p=6555
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=656
+++ b/index.html?p=656
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6561
+++ b/index.html?p=6561
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6592
+++ b/index.html?p=6592
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=66
+++ b/index.html?p=66
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6602
+++ b/index.html?p=6602
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6607
+++ b/index.html?p=6607
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6617
+++ b/index.html?p=6617
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=662
+++ b/index.html?p=662
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6622
+++ b/index.html?p=6622
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6638
+++ b/index.html?p=6638
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6669
+++ b/index.html?p=6669
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6675
+++ b/index.html?p=6675
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6680
+++ b/index.html?p=6680
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6689
+++ b/index.html?p=6689
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6693
+++ b/index.html?p=6693
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6697
+++ b/index.html?p=6697
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6703
+++ b/index.html?p=6703
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6706
+++ b/index.html?p=6706
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=671
+++ b/index.html?p=671
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6715
+++ b/index.html?p=6715
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6726
+++ b/index.html?p=6726
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6732
+++ b/index.html?p=6732
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6736
+++ b/index.html?p=6736
@@ -21,15 +21,10 @@
   <meta property="og:description" content="license implications when packaging non-OSI approved software TrueCrypt for openSUSE" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6740
+++ b/index.html?p=6740
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6743
+++ b/index.html?p=6743
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6746
+++ b/index.html?p=6746
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6770
+++ b/index.html?p=6770
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6775
+++ b/index.html?p=6775
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=678
+++ b/index.html?p=678
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6782
+++ b/index.html?p=6782
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6789
+++ b/index.html?p=6789
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6793
+++ b/index.html?p=6793
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6810
+++ b/index.html?p=6810
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6817
+++ b/index.html?p=6817
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=682
+++ b/index.html?p=682
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6822
+++ b/index.html?p=6822
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=684
+++ b/index.html?p=684
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6847
+++ b/index.html?p=6847
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6858
+++ b/index.html?p=6858
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6882
+++ b/index.html?p=6882
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6894
+++ b/index.html?p=6894
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6896
+++ b/index.html?p=6896
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=69
+++ b/index.html?p=69
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6902
+++ b/index.html?p=6902
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6922
+++ b/index.html?p=6922
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6927
+++ b/index.html?p=6927
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6933
+++ b/index.html?p=6933
@@ -21,15 +21,10 @@
   <meta property="og:description" content="openSUSE Education team is proud to present openSUSE Edu Li-f-e (Linux for Education) based on openSUSE 11.4. The aim of this DVD is to provide complete education and development resources for parents, students, teachers as well as IT admins running labs at educational institutes." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6959
+++ b/index.html?p=6959
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=696
+++ b/index.html?p=696
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=6972
+++ b/index.html?p=6972
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7
+++ b/index.html?p=7
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=70
+++ b/index.html?p=70
@@ -21,15 +21,10 @@
   <meta property="og:description" content="If you just want to search for bugs in Bugzilla, it's (a bit) painful: start the browser, type in the URL, insert your login and password and try to find out where to go. There is an easier way to do: pybugz for commandline lovers!" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7019
+++ b/index.html?p=7019
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=702
+++ b/index.html?p=702
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=705
+++ b/index.html?p=705
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7055
+++ b/index.html?p=7055
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7062
+++ b/index.html?p=7062
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=707
+++ b/index.html?p=707
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7089
+++ b/index.html?p=7089
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7097
+++ b/index.html?p=7097
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=71
+++ b/index.html?p=71
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=710
+++ b/index.html?p=710
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7106
+++ b/index.html?p=7106
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7132
+++ b/index.html?p=7132
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Gnome 3 - Your new Linux Desktop" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7133
+++ b/index.html?p=7133
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7134
+++ b/index.html?p=7134
@@ -21,15 +21,10 @@
   <meta property="og:description" content="New features - made it easy" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7135
+++ b/index.html?p=7135
@@ -21,15 +21,10 @@
   <meta property="og:description" content="no window decoration, no taskbar" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7136
+++ b/index.html?p=7136
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Gnome 3 on Fedora" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7137
+++ b/index.html?p=7137
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Gnome 3 on openSUSE 11.4" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7138
+++ b/index.html?p=7138
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Gnome 3 application launcher " />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7139
+++ b/index.html?p=7139
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Gnome 3 application launcher Firefox" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7140
+++ b/index.html?p=7140
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Activity window" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7141
+++ b/index.html?p=7141
@@ -21,15 +21,10 @@
   <meta property="og:description" content="system tray &#38; notification" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7142
+++ b/index.html?p=7142
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Notifiaction popups" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7143
+++ b/index.html?p=7143
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Application start a way to replace traditionnal menu" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7144
+++ b/index.html?p=7144
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Redisigned workspace &#38; better user interface" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7145
+++ b/index.html?p=7145
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Conclusions" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7146
+++ b/index.html?p=7146
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Thanks" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7149
+++ b/index.html?p=7149
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7168
+++ b/index.html?p=7168
@@ -21,15 +21,10 @@
   <meta property="og:description" content="ETHZ building" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=717
+++ b/index.html?p=717
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7170
+++ b/index.html?p=7170
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7189
+++ b/index.html?p=7189
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7195
+++ b/index.html?p=7195
@@ -21,15 +21,10 @@
   <meta property="og:description" content="This gives some thoughts to problems with our bugzilla and ways to better track our bugs." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=72
+++ b/index.html?p=72
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=720
+++ b/index.html?p=720
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7225
+++ b/index.html?p=7225
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7237
+++ b/index.html?p=7237
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7242
+++ b/index.html?p=7242
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=726
+++ b/index.html?p=726
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7270
+++ b/index.html?p=7270
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7273
+++ b/index.html?p=7273
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7278
+++ b/index.html?p=7278
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7288
+++ b/index.html?p=7288
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7296
+++ b/index.html?p=7296
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=73
+++ b/index.html?p=73
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7303
+++ b/index.html?p=7303
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7309
+++ b/index.html?p=7309
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7315
+++ b/index.html?p=7315
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Brief report on the Wine talk at LinuxTag 2011 in Berlin, by Christian Boltz and Marcus Meissner. " />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7326
+++ b/index.html?p=7326
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7332
+++ b/index.html?p=7332
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7348
+++ b/index.html?p=7348
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7350
+++ b/index.html?p=7350
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7353
+++ b/index.html?p=7353
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7366
+++ b/index.html?p=7366
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=738
+++ b/index.html?p=738
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7384
+++ b/index.html?p=7384
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7393
+++ b/index.html?p=7393
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=74
+++ b/index.html?p=74
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=743
+++ b/index.html?p=743
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7433
+++ b/index.html?p=7433
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7439
+++ b/index.html?p=7439
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7473
+++ b/index.html?p=7473
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7479
+++ b/index.html?p=7479
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7486
+++ b/index.html?p=7486
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7499
+++ b/index.html?p=7499
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=75
+++ b/index.html?p=75
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=750
+++ b/index.html?p=750
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7510
+++ b/index.html?p=7510
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7520
+++ b/index.html?p=7520
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7528
+++ b/index.html?p=7528
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=754
+++ b/index.html?p=754
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7565
+++ b/index.html?p=7565
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7569
+++ b/index.html?p=7569
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7575
+++ b/index.html?p=7575
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7582
+++ b/index.html?p=7582
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7585
+++ b/index.html?p=7585
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7592
+++ b/index.html?p=7592
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=76
+++ b/index.html?p=76
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7600
+++ b/index.html?p=7600
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7610
+++ b/index.html?p=7610
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7616
+++ b/index.html?p=7616
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7620
+++ b/index.html?p=7620
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7624
+++ b/index.html?p=7624
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7635
+++ b/index.html?p=7635
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7643
+++ b/index.html?p=7643
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7649
+++ b/index.html?p=7649
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7659
+++ b/index.html?p=7659
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7670
+++ b/index.html?p=7670
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7678
+++ b/index.html?p=7678
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7683
+++ b/index.html?p=7683
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7696
+++ b/index.html?p=7696
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7713
+++ b/index.html?p=7713
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7721
+++ b/index.html?p=7721
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7726
+++ b/index.html?p=7726
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7734
+++ b/index.html?p=7734
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7739
+++ b/index.html?p=7739
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7758
+++ b/index.html?p=7758
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7762
+++ b/index.html?p=7762
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7787
+++ b/index.html?p=7787
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7797
+++ b/index.html?p=7797
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7802
+++ b/index.html?p=7802
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7806
+++ b/index.html?p=7806
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7816
+++ b/index.html?p=7816
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7899
+++ b/index.html?p=7899
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7906
+++ b/index.html?p=7906
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7911
+++ b/index.html?p=7911
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7922
+++ b/index.html?p=7922
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7943
+++ b/index.html?p=7943
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7949
+++ b/index.html?p=7949
@@ -23,15 +23,10 @@
 I like to give a very subjective overview about the current state, so the rumors have something to eat ;-)" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7971
+++ b/index.html?p=7971
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7976
+++ b/index.html?p=7976
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7982
+++ b/index.html?p=7982
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=7994
+++ b/index.html?p=7994
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8003
+++ b/index.html?p=8003
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8048
+++ b/index.html?p=8048
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8076
+++ b/index.html?p=8076
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=81
+++ b/index.html?p=81
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8106
+++ b/index.html?p=8106
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8124
+++ b/index.html?p=8124
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8125
+++ b/index.html?p=8125
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8141
+++ b/index.html?p=8141
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=816
+++ b/index.html?p=816
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8194
+++ b/index.html?p=8194
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=82
+++ b/index.html?p=82
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=820
+++ b/index.html?p=820
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8214
+++ b/index.html?p=8214
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8224
+++ b/index.html?p=8224
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8241
+++ b/index.html?p=8241
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8254
+++ b/index.html?p=8254
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8258
+++ b/index.html?p=8258
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8269
+++ b/index.html?p=8269
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8285
+++ b/index.html?p=8285
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8301
+++ b/index.html?p=8301
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8309
+++ b/index.html?p=8309
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8350
+++ b/index.html?p=8350
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8365
+++ b/index.html?p=8365
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=838
+++ b/index.html?p=838
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8390
+++ b/index.html?p=8390
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8410
+++ b/index.html?p=8410
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8417
+++ b/index.html?p=8417
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8446
+++ b/index.html?p=8446
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8467
+++ b/index.html?p=8467
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8492
+++ b/index.html?p=8492
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=850
+++ b/index.html?p=850
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=852
+++ b/index.html?p=852
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8523
+++ b/index.html?p=8523
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8540
+++ b/index.html?p=8540
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8548
+++ b/index.html?p=8548
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8571
+++ b/index.html?p=8571
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8588
+++ b/index.html?p=8588
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8597
+++ b/index.html?p=8597
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8604
+++ b/index.html?p=8604
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8614
+++ b/index.html?p=8614
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8620
+++ b/index.html?p=8620
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8628
+++ b/index.html?p=8628
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8635
+++ b/index.html?p=8635
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8656
+++ b/index.html?p=8656
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8668
+++ b/index.html?p=8668
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=867
+++ b/index.html?p=867
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8678
+++ b/index.html?p=8678
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8700
+++ b/index.html?p=8700
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8716
+++ b/index.html?p=8716
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8725
+++ b/index.html?p=8725
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=873
+++ b/index.html?p=873
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8736
+++ b/index.html?p=8736
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8748
+++ b/index.html?p=8748
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8763
+++ b/index.html?p=8763
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8768
+++ b/index.html?p=8768
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8783
+++ b/index.html?p=8783
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8788
+++ b/index.html?p=8788
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8793
+++ b/index.html?p=8793
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8800
+++ b/index.html?p=8800
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8814
+++ b/index.html?p=8814
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8829
+++ b/index.html?p=8829
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=883
+++ b/index.html?p=883
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8833
+++ b/index.html?p=8833
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8837
+++ b/index.html?p=8837
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8868
+++ b/index.html?p=8868
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8888
+++ b/index.html?p=8888
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8892
+++ b/index.html?p=8892
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8894
+++ b/index.html?p=8894
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=890
+++ b/index.html?p=890
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8923
+++ b/index.html?p=8923
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8936
+++ b/index.html?p=8936
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8943
+++ b/index.html?p=8943
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8949
+++ b/index.html?p=8949
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=896
+++ b/index.html?p=896
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8961
+++ b/index.html?p=8961
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8972
+++ b/index.html?p=8972
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8975
+++ b/index.html?p=8975
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=8980
+++ b/index.html?p=8980
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=899
+++ b/index.html?p=899
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9
+++ b/index.html?p=9
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=901
+++ b/index.html?p=901
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9014
+++ b/index.html?p=9014
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9025
+++ b/index.html?p=9025
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9029
+++ b/index.html?p=9029
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9035
+++ b/index.html?p=9035
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9045
+++ b/index.html?p=9045
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9053
+++ b/index.html?p=9053
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=906
+++ b/index.html?p=906
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9062
+++ b/index.html?p=9062
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9069
+++ b/index.html?p=9069
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9083
+++ b/index.html?p=9083
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=909
+++ b/index.html?p=909
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=91
+++ b/index.html?p=91
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9115
+++ b/index.html?p=9115
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9128
+++ b/index.html?p=9128
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9175
+++ b/index.html?p=9175
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=918
+++ b/index.html?p=918
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9198
+++ b/index.html?p=9198
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=92
+++ b/index.html?p=92
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9215
+++ b/index.html?p=9215
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9218
+++ b/index.html?p=9218
@@ -21,15 +21,10 @@
   <meta property="og:description" content="fglrx 13.1 amd-ccc &#38; fgl_glxgears" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9219
+++ b/index.html?p=9219
@@ -21,15 +21,10 @@
   <meta property="og:description" content="fglrx &#38; 3d effects kde 4.9.5 on openSUSE 12.2" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=922
+++ b/index.html?p=922
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9221
+++ b/index.html?p=9221
@@ -21,15 +21,10 @@
   <meta property="og:description" content="flash film ( osc13 Thessaloniki teasing )" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9228
+++ b/index.html?p=9228
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9233
+++ b/index.html?p=9233
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9237
+++ b/index.html?p=9237
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=924
+++ b/index.html?p=924
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9244
+++ b/index.html?p=9244
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=927
+++ b/index.html?p=927
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9274
+++ b/index.html?p=9274
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=928
+++ b/index.html?p=928
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9283
+++ b/index.html?p=9283
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9288
+++ b/index.html?p=9288
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9295
+++ b/index.html?p=9295
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=93
+++ b/index.html?p=93
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9304
+++ b/index.html?p=9304
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=931
+++ b/index.html?p=931
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9316
+++ b/index.html?p=9316
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9318
+++ b/index.html?p=9318
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9327
+++ b/index.html?p=9327
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=933
+++ b/index.html?p=933
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9331
+++ b/index.html?p=9331
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9342
+++ b/index.html?p=9342
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9354
+++ b/index.html?p=9354
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9360
+++ b/index.html?p=9360
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9365
+++ b/index.html?p=9365
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9382
+++ b/index.html?p=9382
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9394
+++ b/index.html?p=9394
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=94
+++ b/index.html?p=94
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=940
+++ b/index.html?p=940
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9412
+++ b/index.html?p=9412
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9419
+++ b/index.html?p=9419
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9432
+++ b/index.html?p=9432
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9440
+++ b/index.html?p=9440
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9454
+++ b/index.html?p=9454
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9460
+++ b/index.html?p=9460
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9497
+++ b/index.html?p=9497
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=95
+++ b/index.html?p=95
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=951
+++ b/index.html?p=951
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9578
+++ b/index.html?p=9578
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9587
+++ b/index.html?p=9587
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=96
+++ b/index.html?p=96
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9601
+++ b/index.html?p=9601
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9627
+++ b/index.html?p=9627
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9647
+++ b/index.html?p=9647
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=966
+++ b/index.html?p=966
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9662
+++ b/index.html?p=9662
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9671
+++ b/index.html?p=9671
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=969
+++ b/index.html?p=969
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9699
+++ b/index.html?p=9699
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9707
+++ b/index.html?p=9707
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=971
+++ b/index.html?p=971
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=973
+++ b/index.html?p=973
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=974
+++ b/index.html?p=974
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9752
+++ b/index.html?p=9752
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9754
+++ b/index.html?p=9754
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9757
+++ b/index.html?p=9757
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9823
+++ b/index.html?p=9823
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9850
+++ b/index.html?p=9850
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9856
+++ b/index.html?p=9856
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9888
+++ b/index.html?p=9888
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=99
+++ b/index.html?p=99
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9913
+++ b/index.html?p=9913
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9924
+++ b/index.html?p=9924
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9935
+++ b/index.html?p=9935
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9949
+++ b/index.html?p=9949
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9954
+++ b/index.html?p=9954
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=996
+++ b/index.html?p=996
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9973
+++ b/index.html?p=9973
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/index.html?p=9978
+++ b/index.html?p=9978
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/10/index.html
+++ b/page/10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/100/index.html
+++ b/page/100/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/101/index.html
+++ b/page/101/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/102/index.html
+++ b/page/102/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/103/index.html
+++ b/page/103/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/104/index.html
+++ b/page/104/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/105/index.html
+++ b/page/105/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/106/index.html
+++ b/page/106/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/107/index.html
+++ b/page/107/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/108/index.html
+++ b/page/108/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/109/index.html
+++ b/page/109/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/11/index.html
+++ b/page/11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/110/index.html
+++ b/page/110/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/111/index.html
+++ b/page/111/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/112/index.html
+++ b/page/112/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/113/index.html
+++ b/page/113/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/114/index.html
+++ b/page/114/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/115/index.html
+++ b/page/115/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/116/index.html
+++ b/page/116/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/117/index.html
+++ b/page/117/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/118/index.html
+++ b/page/118/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/119/index.html
+++ b/page/119/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/12/index.html
+++ b/page/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/120/index.html
+++ b/page/120/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/121/index.html
+++ b/page/121/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/122/index.html
+++ b/page/122/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/123/index.html
+++ b/page/123/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/124/index.html
+++ b/page/124/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/125/index.html
+++ b/page/125/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/126/index.html
+++ b/page/126/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/127/index.html
+++ b/page/127/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/128/index.html
+++ b/page/128/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/129/index.html
+++ b/page/129/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/13/index.html
+++ b/page/13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/130/index.html
+++ b/page/130/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/131/index.html
+++ b/page/131/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/132/index.html
+++ b/page/132/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/133/index.html
+++ b/page/133/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/134/index.html
+++ b/page/134/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/135/index.html
+++ b/page/135/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/14/index.html
+++ b/page/14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/15/index.html
+++ b/page/15/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/16/index.html
+++ b/page/16/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/17/index.html
+++ b/page/17/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/18/index.html
+++ b/page/18/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/19/index.html
+++ b/page/19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/2/index.html
+++ b/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/20/index.html
+++ b/page/20/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/21/index.html
+++ b/page/21/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/22/index.html
+++ b/page/22/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/23/index.html
+++ b/page/23/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/24/index.html
+++ b/page/24/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/25/index.html
+++ b/page/25/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/26/index.html
+++ b/page/26/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/27/index.html
+++ b/page/27/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/28/index.html
+++ b/page/28/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/29/index.html
+++ b/page/29/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/3/index.html
+++ b/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/30/index.html
+++ b/page/30/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/31/index.html
+++ b/page/31/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/32/index.html
+++ b/page/32/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/33/index.html
+++ b/page/33/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/34/index.html
+++ b/page/34/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/35/index.html
+++ b/page/35/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/36/index.html
+++ b/page/36/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/37/index.html
+++ b/page/37/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/38/index.html
+++ b/page/38/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/39/index.html
+++ b/page/39/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/4/index.html
+++ b/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/40/index.html
+++ b/page/40/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/41/index.html
+++ b/page/41/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/42/index.html
+++ b/page/42/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/43/index.html
+++ b/page/43/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/44/index.html
+++ b/page/44/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/45/index.html
+++ b/page/45/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/46/index.html
+++ b/page/46/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/47/index.html
+++ b/page/47/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/48/index.html
+++ b/page/48/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/49/index.html
+++ b/page/49/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/5/index.html
+++ b/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/50/index.html
+++ b/page/50/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/51/index.html
+++ b/page/51/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/52/index.html
+++ b/page/52/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/53/index.html
+++ b/page/53/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/54/index.html
+++ b/page/54/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/55/index.html
+++ b/page/55/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/56/index.html
+++ b/page/56/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/57/index.html
+++ b/page/57/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/58/index.html
+++ b/page/58/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/59/index.html
+++ b/page/59/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/6/index.html
+++ b/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/60/index.html
+++ b/page/60/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/61/index.html
+++ b/page/61/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/62/index.html
+++ b/page/62/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/63/index.html
+++ b/page/63/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/64/index.html
+++ b/page/64/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/65/index.html
+++ b/page/65/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/66/index.html
+++ b/page/66/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/67/index.html
+++ b/page/67/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/68/index.html
+++ b/page/68/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/69/index.html
+++ b/page/69/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/7/index.html
+++ b/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/70/index.html
+++ b/page/70/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/71/index.html
+++ b/page/71/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/72/index.html
+++ b/page/72/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/73/index.html
+++ b/page/73/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/74/index.html
+++ b/page/74/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/75/index.html
+++ b/page/75/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/76/index.html
+++ b/page/76/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/77/index.html
+++ b/page/77/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/78/index.html
+++ b/page/78/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/79/index.html
+++ b/page/79/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/8/index.html
+++ b/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
@@ -1127,7 +1122,6 @@ reboot</code></p>
   <link rel='stylesheet' id='mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/mediaelementplayer.min.css?ver=2.22.0' type='text/css' media='all' />
 <link rel='stylesheet' id='wp-mediaelement-css'  href='https://lizards.opensuse.org/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=4.7.5' type='text/css' media='all' />
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/wp-embed.min.js?ver=4.7.5'></script>
-<script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
 <script type='text/javascript' src='https://lizards.opensuse.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
 <script type='text/javascript'>
 /* <![CDATA[ */

--- a/page/80/index.html
+++ b/page/80/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/81/index.html
+++ b/page/81/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/82/index.html
+++ b/page/82/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/83/index.html
+++ b/page/83/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/84/index.html
+++ b/page/84/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/85/index.html
+++ b/page/85/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/86/index.html
+++ b/page/86/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/87/index.html
+++ b/page/87/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/88/index.html
+++ b/page/88/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/89/index.html
+++ b/page/89/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/9/index.html
+++ b/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/90/index.html
+++ b/page/90/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/91/index.html
+++ b/page/91/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/92/index.html
+++ b/page/92/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/93/index.html
+++ b/page/93/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/94/index.html
+++ b/page/94/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/95/index.html
+++ b/page/95/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/96/index.html
+++ b/page/96/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/97/index.html
+++ b/page/97/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/98/index.html
+++ b/page/98/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/page/99/index.html
+++ b/page/99/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Blogs and Ramblings of the openSUSE Members" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/1/index.html
+++ b/tag/1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/11-11/index.html
+++ b/tag/11-11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/11-2/index.html
+++ b/tag/11-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/11-3/index.html
+++ b/tag/11-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/11-3/page/2/index.html
+++ b/tag/11-3/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/11-4/index.html
+++ b/tag/11-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/11-4/page/2/index.html
+++ b/tag/11-4/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/11-4/page/3/index.html
+++ b/tag/11-4/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/11-4/page/4/index.html
+++ b/tag/11-4/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/11-4/page/5/index.html
+++ b/tag/11-4/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/12-1/index.html
+++ b/tag/12-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/12-1/page/2/index.html
+++ b/tag/12-1/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/12-1/page/3/index.html
+++ b/tag/12-1/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/12-1/page/4/index.html
+++ b/tag/12-1/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/12-2/index.html
+++ b/tag/12-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/12-2/page/2/index.html
+++ b/tag/12-2/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/12-2/page/3/index.html
+++ b/tag/12-2/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/12-3/index.html
+++ b/tag/12-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/12-3/page/2/index.html
+++ b/tag/12-3/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/12-3/page/3/index.html
+++ b/tag/12-3/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/12/index.html
+++ b/tag/12/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/13-1/index.html
+++ b/tag/13-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/13-1/page/2/index.html
+++ b/tag/13-1/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/13-1/page/3/index.html
+++ b/tag/13-1/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/13-2/index.html
+++ b/tag/13-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/13-2/page/2/index.html
+++ b/tag/13-2/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/2-6-37/index.html
+++ b/tag/2-6-37/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/2011/index.html
+++ b/tag/2011/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Brief report on the Wine talk at LinuxTag 2011 in Berlin, by Christian Boltz and Marcus Meissner. " />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/2014/index.html
+++ b/tag/2014/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/2015/index.html
+++ b/tag/2015/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/3-19/index.html
+++ b/tag/3-19/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/3d/index.html
+++ b/tag/3d/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/42-1/index.html
+++ b/tag/42-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/42-2/index.html
+++ b/tag/42-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/64-bit/index.html
+++ b/tag/64-bit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/64-bits/index.html
+++ b/tag/64-bits/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/aclocal/index.html
+++ b/tag/aclocal/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/administration/index.html
+++ b/tag/administration/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/adobe/index.html
+++ b/tag/adobe/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/advanced/index.html
+++ b/tag/advanced/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/advocates/index.html
+++ b/tag/advocates/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/akademy/index.html
+++ b/tag/akademy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/alsa/index.html
+++ b/tag/alsa/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/altimagebuild/index.html
+++ b/tag/altimagebuild/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/amarok/index.html
+++ b/tag/amarok/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ambassador/index.html
+++ b/tag/ambassador/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ambassadors/index.html
+++ b/tag/ambassadors/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/amd/index.html
+++ b/tag/amd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/amd/page/2/index.html
+++ b/tag/amd/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/amd/page/3/index.html
+++ b/tag/amd/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/amd/page/4/index.html
+++ b/tag/amd/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/amd/page/5/index.html
+++ b/tag/amd/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/android/index.html
+++ b/tag/android/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/anniversary/index.html
+++ b/tag/anniversary/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/announcements/index.html
+++ b/tag/announcements/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ant/index.html
+++ b/tag/ant/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/appliances/index.html
+++ b/tag/appliances/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/application/index.html
+++ b/tag/application/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/apps/index.html
+++ b/tag/apps/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ar-5007/index.html
+++ b/tag/ar-5007/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/arm/index.html
+++ b/tag/arm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/arm/page/2/index.html
+++ b/tag/arm/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/arm6/index.html
+++ b/tag/arm6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/arm7/index.html
+++ b/tag/arm7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/arm7l/index.html
+++ b/tag/arm7l/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/artwork-2/index.html
+++ b/tag/artwork-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/association/index.html
+++ b/tag/association/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/astrogarrobo/index.html
+++ b/tag/astrogarrobo/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/astronomy/index.html
+++ b/tag/astronomy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/athens/index.html
+++ b/tag/athens/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/atheros/index.html
+++ b/tag/atheros/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ati/index.html
+++ b/tag/ati/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ati/page/2/index.html
+++ b/tag/ati/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ati/page/3/index.html
+++ b/tag/ati/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ati/page/4/index.html
+++ b/tag/ati/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ati/page/5/index.html
+++ b/tag/ati/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/atix/index.html
+++ b/tag/atix/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/audio/index.html
+++ b/tag/audio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/autoconf/index.html
+++ b/tag/autoconf/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/automake/index.html
+++ b/tag/automake/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/autotools/index.html
+++ b/tag/autotools/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/autoyast/index.html
+++ b/tag/autoyast/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/aws/index.html
+++ b/tag/aws/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ayatana/index.html
+++ b/tag/ayatana/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/azure/index.html
+++ b/tag/azure/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/backport/index.html
+++ b/tag/backport/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/backup/index.html
+++ b/tag/backup/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/bacula/index.html
+++ b/tag/bacula/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/banana-pi-m2/index.html
+++ b/tag/banana-pi-m2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/banana-pi/index.html
+++ b/tag/banana-pi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/banshee/index.html
+++ b/tag/banshee/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/bareos/index.html
+++ b/tag/bareos/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/bash/index.html
+++ b/tag/bash/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/bbq/index.html
+++ b/tag/bbq/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/bcache/index.html
+++ b/tag/bcache/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/bee-keeping/index.html
+++ b/tag/bee-keeping/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/beekeeping/index.html
+++ b/tag/beekeeping/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/beijing/index.html
+++ b/tag/beijing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/benchmarking/index.html
+++ b/tag/benchmarking/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/berlin/index.html
+++ b/tag/berlin/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Brief report on the Wine talk at LinuxTag 2011 in Berlin, by Christian Boltz and Marcus Meissner. " />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/berlios/index.html
+++ b/tag/berlios/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/beta/index.html
+++ b/tag/beta/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/bios/index.html
+++ b/tag/bios/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/birdfont/index.html
+++ b/tag/birdfont/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/birthday/index.html
+++ b/tag/birthday/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/blender/index.html
+++ b/tag/blender/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/blog/index.html
+++ b/tag/blog/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/board/index.html
+++ b/tag/board/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/bonding/index.html
+++ b/tag/bonding/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/boosters/index.html
+++ b/tag/boosters/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/booth/index.html
+++ b/tag/booth/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/booting/index.html
+++ b/tag/booting/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/bootloader/index.html
+++ b/tag/bootloader/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/branch/index.html
+++ b/tag/branch/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/btrfs/index.html
+++ b/tag/btrfs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/bugs/index.html
+++ b/tag/bugs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="If you just want to search for bugs in Bugzilla, it's (a bit) painful: start the browser, type in the URL, insert your login and password and try to find out where to go. There is an easier way to do: pybugz for commandline lovers!" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/bugzilla/index.html
+++ b/tag/bugzilla/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="If you just want to search for bugs in Bugzilla, it's (a bit) painful: start the browser, type in the URL, insert your login and password and try to find out where to go. There is an easier way to do: pybugz for commandline lovers!" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/build-service/index.html
+++ b/tag/build-service/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/build-service/page/2/index.html
+++ b/tag/build-service/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/build/index.html
+++ b/tag/build/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/buildservice/index.html
+++ b/tag/buildservice/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/business/index.html
+++ b/tag/business/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/button-order/index.html
+++ b/tag/button-order/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/c-language/index.html
+++ b/tag/c-language/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/c/index.html
+++ b/tag/c/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/caching/index.html
+++ b/tag/caching/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/calendar/index.html
+++ b/tag/calendar/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/calibre/index.html
+++ b/tag/calibre/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/call/index.html
+++ b/tag/call/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/centroamerica/index.html
+++ b/tag/centroamerica/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/cfp/index.html
+++ b/tag/cfp/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/chatweek/index.html
+++ b/tag/chatweek/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/cheatsheet/index.html
+++ b/tag/cheatsheet/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/chemnitz/index.html
+++ b/tag/chemnitz/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/china/index.html
+++ b/tag/china/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/chrome/index.html
+++ b/tag/chrome/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ci/index.html
+++ b/tag/ci/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/cifs/index.html
+++ b/tag/cifs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/cinnamon/index.html
+++ b/tag/cinnamon/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/classroom/index.html
+++ b/tag/classroom/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/cli/index.html
+++ b/tag/cli/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/clicfs/index.html
+++ b/tag/clicfs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/cloud/index.html
+++ b/tag/cloud/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/clt2010/index.html
+++ b/tag/clt2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/collaboration/index.html
+++ b/tag/collaboration/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/collaborative/index.html
+++ b/tag/collaborative/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/color/index.html
+++ b/tag/color/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/community-event/index.html
+++ b/tag/community-event/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/community/index.html
+++ b/tag/community/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/community/page/2/index.html
+++ b/tag/community/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/community/page/3/index.html
+++ b/tag/community/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/community/page/4/index.html
+++ b/tag/community/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/community_week/index.html
+++ b/tag/community_week/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/comparison/index.html
+++ b/tag/comparison/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/compiz-unity-opensuse-ubuntu-development-build-service-11-4-beta-desktop-world-domination/index.html
+++ b/tag/compiz-unity-opensuse-ubuntu-development-build-service-11-4-beta-desktop-world-domination/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/conference/index.html
+++ b/tag/conference/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/configuration/index.html
+++ b/tag/configuration/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/connect/index.html
+++ b/tag/connect/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/console/index.html
+++ b/tag/console/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/containers/index.html
+++ b/tag/containers/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="A matryoshka doll, also known as a Russian nesting doll or a babushka doll, is a set of dolls of decreasing sizes placed one inside the other. Virtualization is a concept similar to the Matryoshka analogy. There is another system running inside the host machine. So it is box in a box. Each performs and executes exactly like a stand-alone server; a container can be rebooted independently and have root access, users, IP addresses, memory, processes, files, applications, system libraries and configuration files." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/contrib/index.html
+++ b/tag/contrib/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/contribute/index.html
+++ b/tag/contribute/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/contributing/index.html
+++ b/tag/contributing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/contribution/index.html
+++ b/tag/contribution/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/copy-com/index.html
+++ b/tag/copy-com/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/cron/index.html
+++ b/tag/cron/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/cross-build/index.html
+++ b/tag/cross-build/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/cross-compilation/index.html
+++ b/tag/cross-compilation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/cross-development/index.html
+++ b/tag/cross-development/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/crosscompile/index.html
+++ b/tag/crosscompile/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/css/index.html
+++ b/tag/css/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/csv/index.html
+++ b/tag/csv/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/curlwwwfs/index.html
+++ b/tag/curlwwwfs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/danke/index.html
+++ b/tag/danke/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/daps/index.html
+++ b/tag/daps/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/database/index.html
+++ b/tag/database/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/dban/index.html
+++ b/tag/dban/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ddclient/index.html
+++ b/tag/ddclient/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/debugging/index.html
+++ b/tag/debugging/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/debuginfo/index.html
+++ b/tag/debuginfo/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/decks/index.html
+++ b/tag/decks/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/desktop-kde/index.html
+++ b/tag/desktop-kde/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/desktop/index.html
+++ b/tag/desktop/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/developers/index.html
+++ b/tag/developers/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/development/index.html
+++ b/tag/development/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/dhcp-proxypac-wpaddat/index.html
+++ b/tag/dhcp-proxypac-wpaddat/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/dhcpd/index.html
+++ b/tag/dhcpd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/diablo/index.html
+++ b/tag/diablo/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/dictconv/index.html
+++ b/tag/dictconv/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/dictionaries/index.html
+++ b/tag/dictionaries/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/disk/index.html
+++ b/tag/disk/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/distribution/index.html
+++ b/tag/distribution/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/distributions/index.html
+++ b/tag/distributions/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/dj/index.html
+++ b/tag/dj/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/docbook/index.html
+++ b/tag/docbook/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/documentation/index.html
+++ b/tag/documentation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/downstream/index.html
+++ b/tag/downstream/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/dreamchess/index.html
+++ b/tag/dreamchess/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/driver/index.html
+++ b/tag/driver/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/drm/index.html
+++ b/tag/drm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/dud/index.html
+++ b/tag/dud/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/dvb/index.html
+++ b/tag/dvb/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/dvd/index.html
+++ b/tag/dvd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/dwipe/index.html
+++ b/tag/dwipe/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/dynamic-dns/index.html
+++ b/tag/dynamic-dns/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ebook/index.html
+++ b/tag/ebook/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ebooks/index.html
+++ b/tag/ebooks/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ec2/index.html
+++ b/tag/ec2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ecuador/index.html
+++ b/tag/ecuador/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/editing/index.html
+++ b/tag/editing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/editor/index.html
+++ b/tag/editor/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/edtech/index.html
+++ b/tag/edtech/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/education-technology/index.html
+++ b/tag/education-technology/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/education/index.html
+++ b/tag/education/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/education/page/2/index.html
+++ b/tag/education/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/eduction/index.html
+++ b/tag/eduction/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/efikamx/index.html
+++ b/tag/efikamx/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/election/index.html
+++ b/tag/election/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/elfcloud-fi/index.html
+++ b/tag/elfcloud-fi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/elixir/index.html
+++ b/tag/elixir/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/emacs/index.html
+++ b/tag/emacs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/embedded/index.html
+++ b/tag/embedded/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/emscripten/index.html
+++ b/tag/emscripten/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/encryption/index.html
+++ b/tag/encryption/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/enlightenment/index.html
+++ b/tag/enlightenment/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/enterprise/index.html
+++ b/tag/enterprise/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/entertainment/index.html
+++ b/tag/entertainment/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/epub/index.html
+++ b/tag/epub/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/event/index.html
+++ b/tag/event/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/events/index.html
+++ b/tag/events/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/experience/index.html
+++ b/tag/experience/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/facebook/index.html
+++ b/tag/facebook/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/factory-progress/index.html
+++ b/tag/factory-progress/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/factory/index.html
+++ b/tag/factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/factory/page/2/index.html
+++ b/tag/factory/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/faster/index.html
+++ b/tag/faster/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fate/index.html
+++ b/tag/fate/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/feature/index.html
+++ b/tag/feature/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/featuretracking/index.html
+++ b/tag/featuretracking/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fedora/index.html
+++ b/tag/fedora/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fglrx-legacy/index.html
+++ b/tag/fglrx-legacy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fglrx/index.html
+++ b/tag/fglrx/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fglrx/page/2/index.html
+++ b/tag/fglrx/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fglrx/page/3/index.html
+++ b/tag/fglrx/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fglrx/page/4/index.html
+++ b/tag/fglrx/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fglrx/page/5/index.html
+++ b/tag/fglrx/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fglx/index.html
+++ b/tag/fglx/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/financial-software/index.html
+++ b/tag/financial-software/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/firefox/index.html
+++ b/tag/firefox/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/firmware/index.html
+++ b/tag/firmware/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/flash/index.html
+++ b/tag/flash/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/flgrx-legacy/index.html
+++ b/tag/flgrx-legacy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/flgrx/index.html
+++ b/tag/flgrx/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fli/index.html
+++ b/tag/fli/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/flickr/index.html
+++ b/tag/flickr/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/flisol/index.html
+++ b/tag/flisol/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/flisol2010/index.html
+++ b/tag/flisol2010/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fodsem/index.html
+++ b/tag/fodsem/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/font-hinting/index.html
+++ b/tag/font-hinting/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/font-rendering/index.html
+++ b/tag/font-rendering/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/font/index.html
+++ b/tag/font/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fontforge/index.html
+++ b/tag/fontforge/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fonts/index.html
+++ b/tag/fonts/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/forum/index.html
+++ b/tag/forum/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/forums/index.html
+++ b/tag/forums/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/foscomm2011/index.html
+++ b/tag/foscomm2011/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fosdem/index.html
+++ b/tag/fosdem/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/foss/index.html
+++ b/tag/foss/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fosscomm/index.html
+++ b/tag/fosscomm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/free-software/index.html
+++ b/tag/free-software/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/freebeer/index.html
+++ b/tag/freebeer/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/freecad/index.html
+++ b/tag/freecad/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/freedom/index.html
+++ b/tag/freedom/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fritzing/index.html
+++ b/tag/fritzing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/froscamp/index.html
+++ b/tag/froscamp/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/froscon-events-boosters/index.html
+++ b/tag/froscon-events-boosters/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fscache/index.html
+++ b/tag/fscache/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fun/index.html
+++ b/tag/fun/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/fun/page/2/index.html
+++ b/tag/fun/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/funk/index.html
+++ b/tag/funk/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/game/index.html
+++ b/tag/game/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/games/index.html
+++ b/tag/games/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gaming/index.html
+++ b/tag/gaming/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gcc/index.html
+++ b/tag/gcc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gce/index.html
+++ b/tag/gce/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gems/index.html
+++ b/tag/gems/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/genesi/index.html
+++ b/tag/genesi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/git/index.html
+++ b/tag/git/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/github/index.html
+++ b/tag/github/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/glance/index.html
+++ b/tag/glance/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gnome-3/index.html
+++ b/tag/gnome-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gnome-opensuse-desktop-file-launcher-semantic-ubuntu-ayatana-indicator-11-4-factory/index.html
+++ b/tag/gnome-opensuse-desktop-file-launcher-semantic-ubuntu-ayatana-indicator-11-4-factory/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gnome-shell/index.html
+++ b/tag/gnome-shell/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gnome/index.html
+++ b/tag/gnome/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gnome/page/2/index.html
+++ b/tag/gnome/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gnome3/index.html
+++ b/tag/gnome3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gobby/index.html
+++ b/tag/gobby/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gold/index.html
+++ b/tag/gold/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/google-earth-6-0/index.html
+++ b/tag/google-earth-6-0/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/google-plus/index.html
+++ b/tag/google-plus/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/google/index.html
+++ b/tag/google/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gpick/index.html
+++ b/tag/gpick/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gpio/index.html
+++ b/tag/gpio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/graph/index.html
+++ b/tag/graph/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/graphic-designing/index.html
+++ b/tag/graphic-designing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/graphic/index.html
+++ b/tag/graphic/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/greece/index.html
+++ b/tag/greece/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/greek-community/index.html
+++ b/tag/greek-community/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/groupware/index.html
+++ b/tag/groupware/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gsoc/index.html
+++ b/tag/gsoc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gsoc/page/2/index.html
+++ b/tag/gsoc/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gtk/index.html
+++ b/tag/gtk/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/guayaquil/index.html
+++ b/tag/guayaquil/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/gui/index.html
+++ b/tag/gui/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/hacking/index.html
+++ b/tag/hacking/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/hackweek-v/index.html
+++ b/tag/hackweek-v/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/hackweek/index.html
+++ b/tag/hackweek/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/hamradio/index.html
+++ b/tag/hamradio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/hardware/index.html
+++ b/tag/hardware/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/hdxxxx/index.html
+++ b/tag/hdxxxx/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/helping-hands/index.html
+++ b/tag/helping-hands/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/henne/index.html
+++ b/tag/henne/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/hermes/index.html
+++ b/tag/hermes/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/hongkong/index.html
+++ b/tag/hongkong/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/how-to/index.html
+++ b/tag/how-to/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/howto/index.html
+++ b/tag/howto/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/html/index.html
+++ b/tag/html/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/icons/index.html
+++ b/tag/icons/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/imaging/index.html
+++ b/tag/imaging/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/import/index.html
+++ b/tag/import/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/inadyn/index.html
+++ b/tag/inadyn/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/indicators/index.html
+++ b/tag/indicators/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/indonesian/index.html
+++ b/tag/indonesian/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/infrastructure-mirror-download/index.html
+++ b/tag/infrastructure-mirror-download/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/infrastructure/index.html
+++ b/tag/infrastructure/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/install/index.html
+++ b/tag/install/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/installation-source/index.html
+++ b/tag/installation-source/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/installation/index.html
+++ b/tag/installation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/internal-buildservice/index.html
+++ b/tag/internal-buildservice/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/interview/index.html
+++ b/tag/interview/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/invis/index.html
+++ b/tag/invis/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ipfs/index.html
+++ b/tag/ipfs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ipxe/index.html
+++ b/tag/ipxe/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/irc-bouncer/index.html
+++ b/tag/irc-bouncer/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/irc/index.html
+++ b/tag/irc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/it/index.html
+++ b/tag/it/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/jabber/index.html
+++ b/tag/jabber/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/javascript/index.html
+++ b/tag/javascript/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/jenkins/index.html
+++ b/tag/jenkins/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/jshint/index.html
+++ b/tag/jshint/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/json/index.html
+++ b/tag/json/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kaffeine/index.html
+++ b/tag/kaffeine/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kde-4/index.html
+++ b/tag/kde-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kde-opensuse/index.html
+++ b/tag/kde-opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kde-telepathy/index.html
+++ b/tag/kde-telepathy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kde/index.html
+++ b/tag/kde/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kde/page/2/index.html
+++ b/tag/kde/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kde/page/3/index.html
+++ b/tag/kde/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kde4/index.html
+++ b/tag/kde4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kde43/index.html
+++ b/tag/kde43/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kernel-2-6-37/index.html
+++ b/tag/kernel-2-6-37/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kernel-update/index.html
+++ b/tag/kernel-update/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kernel/index.html
+++ b/tag/kernel/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kernel/page/2/index.html
+++ b/tag/kernel/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kernel/page/3/index.html
+++ b/tag/kernel/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kernel/page/4/index.html
+++ b/tag/kernel/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kernel/page/5/index.html
+++ b/tag/kernel/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/keyboard/index.html
+++ b/tag/keyboard/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kit/index.html
+++ b/tag/kit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kiwi/index.html
+++ b/tag/kiwi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/koffice/index.html
+++ b/tag/koffice/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kontact/index.html
+++ b/tag/kontact/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/korganizer/index.html
+++ b/tag/korganizer/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kotd/index.html
+++ b/tag/kotd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kraft/index.html
+++ b/tag/kraft/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/kvm/index.html
+++ b/tag/kvm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/l3/index.html
+++ b/tag/l3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lanyard/index.html
+++ b/tag/lanyard/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/latex/index.html
+++ b/tag/latex/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="I have started maintaining three packages, namely Texmaker, TeXworks and Rubber, in the Publishing repository. These applications make working with and compiling latex documents user friendly and painless." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/launch-party/index.html
+++ b/tag/launch-party/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/layout/index.html
+++ b/tag/layout/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/leap/index.html
+++ b/tag/leap/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/li-f-e/index.html
+++ b/tag/li-f-e/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/libao/index.html
+++ b/tag/libao/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/libtool/index.html
+++ b/tag/libtool/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/libvirtd/index.html
+++ b/tag/libvirtd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/libzypp/index.html
+++ b/tag/libzypp/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/life/index.html
+++ b/tag/life/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/linpac/index.html
+++ b/tag/linpac/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/linux-magazine/index.html
+++ b/tag/linux-magazine/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/linux-on-android/index.html
+++ b/tag/linux-on-android/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/linux/index.html
+++ b/tag/linux/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/linux/page/2/index.html
+++ b/tag/linux/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/linuxradio/index.html
+++ b/tag/linuxradio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/linuxtag/index.html
+++ b/tag/linuxtag/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lists/index.html
+++ b/tag/lists/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/live/index.html
+++ b/tag/live/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/livecd/index.html
+++ b/tag/livecd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/liveusb/index.html
+++ b/tag/liveusb/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lizards/index.html
+++ b/tag/lizards/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/local-conference/index.html
+++ b/tag/local-conference/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lord/index.html
+++ b/tag/lord/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/los-angeles/index.html
+++ b/tag/los-angeles/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lotro/index.html
+++ b/tag/lotro/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lrl/index.html
+++ b/tag/lrl/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ltsp/index.html
+++ b/tag/ltsp/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lvm/index.html
+++ b/tag/lvm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lvm2/index.html
+++ b/tag/lvm2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lxc/index.html
+++ b/tag/lxc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="A matryoshka doll, also known as a Russian nesting doll or a babushka doll, is a set of dolls of decreasing sizes placed one inside the other. Virtualization is a concept similar to the Matryoshka analogy. There is another system running inside the host machine. So it is box in a box. Each performs and executes exactly like a stand-alone server; a container can be rebooted independently and have root access, users, IP addresses, memory, processes, files, applications, system libraries and configuration files." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lxde-qt/index.html
+++ b/tag/lxde-qt/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lxde/index.html
+++ b/tag/lxde/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lxde/page/2/index.html
+++ b/tag/lxde/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lxml/index.html
+++ b/tag/lxml/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Maybe you know this problem: You have a couple of XML files and you need a specific information. Probably everybody would think of grep or similar tools first. But maybe your query is a bit more complicated than just a simple piece of text. What do do?" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/lxqt/index.html
+++ b/tag/lxqt/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/m17nfonts/index.html
+++ b/tag/m17nfonts/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/maemo/index.html
+++ b/tag/maemo/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/mail/index.html
+++ b/tag/mail/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/mailinglist/index.html
+++ b/tag/mailinglist/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/make/index.html
+++ b/tag/make/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/managua/index.html
+++ b/tag/managua/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/march-2011/index.html
+++ b/tag/march-2011/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/marketing/index.html
+++ b/tag/marketing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/mate/index.html
+++ b/tag/mate/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/medical/index.html
+++ b/tag/medical/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/meeting/index.html
+++ b/tag/meeting/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/meetings/index.html
+++ b/tag/meetings/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/member/index.html
+++ b/tag/member/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/members/index.html
+++ b/tag/members/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/merci/index.html
+++ b/tag/merci/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/microsoft/index.html
+++ b/tag/microsoft/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/minisummit/index.html
+++ b/tag/minisummit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/mint/index.html
+++ b/tag/mint/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/mirror/index.html
+++ b/tag/mirror/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/misc/index.html
+++ b/tag/misc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/mixxx/index.html
+++ b/tag/mixxx/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/mockup/index.html
+++ b/tag/mockup/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/mod-ui/index.html
+++ b/tag/mod-ui/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/monitoring/index.html
+++ b/tag/monitoring/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/mono/index.html
+++ b/tag/mono/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/more/index.html
+++ b/tag/more/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="The hackweek project I worked to create a live graphing utility that displays I/O of processes. Screen-shots, RPM download link, project homepage link,..." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/mouse/index.html
+++ b/tag/mouse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/mozilla/index.html
+++ b/tag/mozilla/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/mp3/index.html
+++ b/tag/mp3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/multiboot/index.html
+++ b/tag/multiboot/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/multimedia/index.html
+++ b/tag/multimedia/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/multimidia/index.html
+++ b/tag/multimidia/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/multisystem/index.html
+++ b/tag/multisystem/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/n810/index.html
+++ b/tag/n810/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/namespace/index.html
+++ b/tag/namespace/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/netbook/index.html
+++ b/tag/netbook/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/netsecurify/index.html
+++ b/tag/netsecurify/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/networking/index.html
+++ b/tag/networking/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/networkmanager/index.html
+++ b/tag/networkmanager/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/new/index.html
+++ b/tag/new/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/news/index.html
+++ b/tag/news/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/nextcloud/index.html
+++ b/tag/nextcloud/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/nexus/index.html
+++ b/tag/nexus/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/nfs/index.html
+++ b/tag/nfs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/nicaragua/index.html
+++ b/tag/nicaragua/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/no-ip/index.html
+++ b/tag/no-ip/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/notifications/index.html
+++ b/tag/notifications/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ntf-3g/index.html
+++ b/tag/ntf-3g/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/nwipe/index.html
+++ b/tag/nwipe/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/obs/index.html
+++ b/tag/obs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/of/index.html
+++ b/tag/of/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/off-topic/index.html
+++ b/tag/off-topic/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/office/index.html
+++ b/tag/office/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/offline-mode/index.html
+++ b/tag/offline-mode/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/online/index.html
+++ b/tag/online/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/open-hardware/index.html
+++ b/tag/open-hardware/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/open-source-community/index.html
+++ b/tag/open-source-community/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/open-source/index.html
+++ b/tag/open-source/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/openfate/index.html
+++ b/tag/openfate/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/openqa-automated-testing/index.html
+++ b/tag/openqa-automated-testing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/openqa/index.html
+++ b/tag/openqa/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/openstack/index.html
+++ b/tag/openstack/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-11-2/index.html
+++ b/tag/opensuse-11-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-11-4/index.html
+++ b/tag/opensuse-11-4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-11/index.html
+++ b/tag/opensuse-11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-12-1/index.html
+++ b/tag/opensuse-12-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-12-3/index.html
+++ b/tag/opensuse-12-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-13-1/index.html
+++ b/tag/opensuse-13-1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-13-2/index.html
+++ b/tag/opensuse-13-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-asia-summit/index.html
+++ b/tag/opensuse-asia-summit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-doc/index.html
+++ b/tag/opensuse-doc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-forum/index.html
+++ b/tag/opensuse-forum/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-id/index.html
+++ b/tag/opensuse-id/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-linux/index.html
+++ b/tag/opensuse-linux/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-lxde/index.html
+++ b/tag/opensuse-lxde/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-mate/index.html
+++ b/tag/opensuse-mate/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-tutorials/index.html
+++ b/tag/opensuse-tutorials/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-tv/index.html
+++ b/tag/opensuse-tv/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse-week/index.html
+++ b/tag/opensuse-week/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse/index.html
+++ b/tag/opensuse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse/page/2/index.html
+++ b/tag/opensuse/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse/page/3/index.html
+++ b/tag/opensuse/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse/page/4/index.html
+++ b/tag/opensuse/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse/page/5/index.html
+++ b/tag/opensuse/page/5/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse/page/6/index.html
+++ b/tag/opensuse/page/6/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse/page/7/index.html
+++ b/tag/opensuse/page/7/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse/page/8/index.html
+++ b/tag/opensuse/page/8/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensuse/page/9/index.html
+++ b/tag/opensuse/page/9/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/opensusearm/index.html
+++ b/tag/opensusearm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/orbit/index.html
+++ b/tag/orbit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/osc-completion-hackweek/index.html
+++ b/tag/osc-completion-hackweek/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/osc/index.html
+++ b/tag/osc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/osc10/index.html
+++ b/tag/osc10/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/osc11/index.html
+++ b/tag/osc11/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/osc13/index.html
+++ b/tag/osc13/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/osc14/index.html
+++ b/tag/osc14/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/osc2011/index.html
+++ b/tag/osc2011/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/osem/index.html
+++ b/tag/osem/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/oss/index.html
+++ b/tag/oss/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/package/index.html
+++ b/tag/package/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/packages/index.html
+++ b/tag/packages/index.html
@@ -23,15 +23,10 @@
 I like to give a very subjective overview about the current state, so the rumors have something to eat ;-)" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/packaging/index.html
+++ b/tag/packaging/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/packet/index.html
+++ b/tag/packet/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/packman/index.html
+++ b/tag/packman/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/panama/index.html
+++ b/tag/panama/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/paris/index.html
+++ b/tag/paris/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/partitioner/index.html
+++ b/tag/partitioner/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/party/index.html
+++ b/tag/party/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/passwords/index.html
+++ b/tag/passwords/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/patch/index.html
+++ b/tag/patch/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/pdf/index.html
+++ b/tag/pdf/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/perl-bootloader/index.html
+++ b/tag/perl-bootloader/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/phase1/index.html
+++ b/tag/phase1/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/php/index.html
+++ b/tag/php/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/pi/index.html
+++ b/tag/pi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/picker/index.html
+++ b/tag/picker/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ping/index.html
+++ b/tag/ping/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/pipelight/index.html
+++ b/tag/pipelight/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/pkg-config/index.html
+++ b/tag/pkg-config/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/plasma/index.html
+++ b/tag/plasma/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/pledge/index.html
+++ b/tag/pledge/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/polish-community/index.html
+++ b/tag/polish-community/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/poll/index.html
+++ b/tag/poll/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/polska-spolecznosc/index.html
+++ b/tag/polska-spolecznosc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/portaudio/index.html
+++ b/tag/portaudio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/poster/index.html
+++ b/tag/poster/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/postgresql-plr/index.html
+++ b/tag/postgresql-plr/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/postgresql/index.html
+++ b/tag/postgresql/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/power/index.html
+++ b/tag/power/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/presentation/index.html
+++ b/tag/presentation/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/prezi/index.html
+++ b/tag/prezi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/profiler/index.html
+++ b/tag/profiler/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/programming/index.html
+++ b/tag/programming/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/progress/index.html
+++ b/tag/progress/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/project/index.html
+++ b/tag/project/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/promo/index.html
+++ b/tag/promo/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/promotion/index.html
+++ b/tag/promotion/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/proxy/index.html
+++ b/tag/proxy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/publishing/index.html
+++ b/tag/publishing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="I have started maintaining three packages, namely Texmaker, TeXworks and Rubber, in the Publishing repository. These applications make working with and compiling latex documents user friendly and painless." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/pulseaudio/index.html
+++ b/tag/pulseaudio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/pxe/index.html
+++ b/tag/pxe/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/python/index.html
+++ b/tag/python/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/qa/index.html
+++ b/tag/qa/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/qemu/index.html
+++ b/tag/qemu/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/qt/index.html
+++ b/tag/qt/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/r/index.html
+++ b/tag/r/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/radeon/index.html
+++ b/tag/radeon/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/radio-marketing/index.html
+++ b/tag/radio-marketing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/radiotux/index.html
+++ b/tag/radiotux/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/raid/index.html
+++ b/tag/raid/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/rails/index.html
+++ b/tag/rails/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/randa/index.html
+++ b/tag/randa/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/raspberry-pi/index.html
+++ b/tag/raspberry-pi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/raspberry/index.html
+++ b/tag/raspberry/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/raspberry/page/2/index.html
+++ b/tag/raspberry/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/real-world/index.html
+++ b/tag/real-world/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/refactoring/index.html
+++ b/tag/refactoring/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/registration/index.html
+++ b/tag/registration/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/relax-ng/index.html
+++ b/tag/relax-ng/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/release-party/index.html
+++ b/tag/release-party/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/release/index.html
+++ b/tag/release/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/releases/index.html
+++ b/tag/releases/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/remote/index.html
+++ b/tag/remote/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/repo/index.html
+++ b/tag/repo/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/report/index.html
+++ b/tag/report/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/repository/index.html
+++ b/tag/repository/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/reproducible-builds/index.html
+++ b/tag/reproducible-builds/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/resolver/index.html
+++ b/tag/resolver/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/retracted/index.html
+++ b/tag/retracted/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/review/index.html
+++ b/tag/review/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/rfc/index.html
+++ b/tag/rfc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/rings/index.html
+++ b/tag/rings/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/robotics/index.html
+++ b/tag/robotics/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/roles/index.html
+++ b/tag/roles/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/rollback/index.html
+++ b/tag/rollback/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/routing/index.html
+++ b/tag/routing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/rpm/index.html
+++ b/tag/rpm/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/rpm/page/2/index.html
+++ b/tag/rpm/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/rpmlint/index.html
+++ b/tag/rpmlint/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/rss/index.html
+++ b/tag/rss/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ruby/index.html
+++ b/tag/ruby/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/samba/index.html
+++ b/tag/samba/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/scale/index.html
+++ b/tag/scale/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/schema-design/index.html
+++ b/tag/schema-design/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/school/index.html
+++ b/tag/school/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/science/index.html
+++ b/tag/science/index.html
@@ -23,15 +23,10 @@
 I like to give a very subjective overview about the current state, so the rumors have something to eat ;-)" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/screencast/index.html
+++ b/tag/screencast/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/screening-team/index.html
+++ b/tag/screening-team/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/screenshots/index.html
+++ b/tag/screenshots/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/script/index.html
+++ b/tag/script/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/sdl/index.html
+++ b/tag/sdl/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/sdl2/index.html
+++ b/tag/sdl2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/search/index.html
+++ b/tag/search/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/second-life/index.html
+++ b/tag/second-life/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/secondlife/index.html
+++ b/tag/secondlife/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/security/index.html
+++ b/tag/security/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/seedbox/index.html
+++ b/tag/seedbox/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/server/index.html
+++ b/tag/server/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/service/index.html
+++ b/tag/service/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/session/index.html
+++ b/tag/session/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/settings/index.html
+++ b/tag/settings/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/silverlight/index.html
+++ b/tag/silverlight/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/skrooge/index.html
+++ b/tag/skrooge/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/skype/index.html
+++ b/tag/skype/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/slides/index.html
+++ b/tag/slides/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/smolt/index.html
+++ b/tag/smolt/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/snapper/index.html
+++ b/tag/snapper/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/software-libre/index.html
+++ b/tag/software-libre/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/software-o-o/index.html
+++ b/tag/software-o-o/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/sprint/index.html
+++ b/tag/sprint/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/sqlalchemy/index.html
+++ b/tag/sqlalchemy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/squashfs/index.html
+++ b/tag/squashfs/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/squid/index.html
+++ b/tag/squid/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/squidview/index.html
+++ b/tag/squidview/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ssd/index.html
+++ b/tag/ssd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ssh/index.html
+++ b/tag/ssh/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/stardict/index.html
+++ b/tag/stardict/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/static-ip/index.html
+++ b/tag/static-ip/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/status/index.html
+++ b/tag/status/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/storage/index.html
+++ b/tag/storage/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/stories/index.html
+++ b/tag/stories/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/strategy/index.html
+++ b/tag/strategy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/studio-api/index.html
+++ b/tag/studio-api/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/studio/index.html
+++ b/tag/studio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/stylesheets/index.html
+++ b/tag/stylesheets/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/subversion/index.html
+++ b/tag/subversion/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/sugar/index.html
+++ b/tag/sugar/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/summit/index.html
+++ b/tag/summit/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/suse-ni/index.html
+++ b/tag/suse-ni/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/suse-studio/index.html
+++ b/tag/suse-studio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/suse/index.html
+++ b/tag/suse/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/susestudio/index.html
+++ b/tag/susestudio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/svn/index.html
+++ b/tag/svn/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/swine-flu/index.html
+++ b/tag/swine-flu/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/swiss/index.html
+++ b/tag/swiss/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/switzerland/index.html
+++ b/tag/switzerland/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/system/index.html
+++ b/tag/system/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/systemd/index.html
+++ b/tag/systemd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/systems-management/index.html
+++ b/tag/systems-management/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/tab-completion/index.html
+++ b/tag/tab-completion/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/table/index.html
+++ b/tag/table/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/talk/index.html
+++ b/tag/talk/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="Brief report on the Wine talk at LinuxTag 2011 in Berlin, by Christian Boltz and Marcus Meissner. " />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/talks/index.html
+++ b/tag/talks/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/tar/index.html
+++ b/tag/tar/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/targitter/index.html
+++ b/tag/targitter/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/team-meeting/index.html
+++ b/tag/team-meeting/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/technology-previews/index.html
+++ b/tag/technology-previews/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/test-team/index.html
+++ b/tag/test-team/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/testing/index.html
+++ b/tag/testing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/thank-you/index.html
+++ b/tag/thank-you/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/the/index.html
+++ b/tag/the/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/tip/index.html
+++ b/tag/tip/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/tips/index.html
+++ b/tag/tips/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/tool/index.html
+++ b/tag/tool/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/toolchain/index.html
+++ b/tag/toolchain/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/tools/index.html
+++ b/tag/tools/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/torrent/index.html
+++ b/tag/torrent/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/trainee/index.html
+++ b/tag/trainee/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/translation/index.html
+++ b/tag/translation/index.html
@@ -23,15 +23,10 @@
 I like to give a very subjective overview about the current state, so the rumors have something to eat ;-)" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/transmission/index.html
+++ b/tag/transmission/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/tsp/index.html
+++ b/tag/tsp/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/tumbleweed/index.html
+++ b/tag/tumbleweed/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/tumbleweed/page/2/index.html
+++ b/tag/tumbleweed/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/turbogears/index.html
+++ b/tag/turbogears/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/tutorial/index.html
+++ b/tag/tutorial/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/tux-geeko-scary-movie/index.html
+++ b/tag/tux-geeko-scary-movie/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/twitter/index.html
+++ b/tag/twitter/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/typefaces/index.html
+++ b/tag/typefaces/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ubuntu/index.html
+++ b/tag/ubuntu/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/udev/index.html
+++ b/tag/udev/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/udf/index.html
+++ b/tag/udf/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/unan/index.html
+++ b/tag/unan/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ungaman/index.html
+++ b/tag/ungaman/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/unified/index.html
+++ b/tag/unified/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/unity/index.html
+++ b/tag/unity/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/unknown-horizons/index.html
+++ b/tag/unknown-horizons/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/unrar/index.html
+++ b/tag/unrar/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/unreal-world/index.html
+++ b/tag/unreal-world/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/update/index.html
+++ b/tag/update/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/updated/index.html
+++ b/tag/updated/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/updates/index.html
+++ b/tag/updates/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/upgrade/index.html
+++ b/tag/upgrade/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/upstream/index.html
+++ b/tag/upstream/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/usability/index.html
+++ b/tag/usability/index.html
@@ -22,15 +22,10 @@
 I have 2 Intel Atom's running for my mail and web servers and I was quite happy with their performances, (by the way I am still happy). Hence I decided to ride the change train and bought the Intel D510 board" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/user/index.html
+++ b/tag/user/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/userpage/index.html
+++ b/tag/userpage/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/utility/index.html
+++ b/tag/utility/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/vamox-ceibo/index.html
+++ b/tag/vamox-ceibo/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/vamox-celeste/index.html
+++ b/tag/vamox-celeste/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/vamox-mate/index.html
+++ b/tag/vamox-mate/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/vamox/index.html
+++ b/tag/vamox/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/verein/index.html
+++ b/tag/verein/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/version/index.html
+++ b/tag/version/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/vftpd/index.html
+++ b/tag/vftpd/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/video/index.html
+++ b/tag/video/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/virtio/index.html
+++ b/tag/virtio/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/virtual-launch-party/index.html
+++ b/tag/virtual-launch-party/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/virtualization-2/index.html
+++ b/tag/virtualization-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="A matryoshka doll, also known as a Russian nesting doll or a babushka doll, is a set of dolls of decreasing sizes placed one inside the other. Virtualization is a concept similar to the Matryoshka analogy. There is another system running inside the host machine. So it is box in a box. Each performs and executes exactly like a stand-alone server; a container can be rebooted independently and have root access, users, IP addresses, memory, processes, files, applications, system libraries and configuration files." />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/vlan/index.html
+++ b/tag/vlan/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/vmware/index.html
+++ b/tag/vmware/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/vote/index.html
+++ b/tag/vote/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/voting/index.html
+++ b/tag/voting/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/web-application/index.html
+++ b/tag/web-application/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/webservice/index.html
+++ b/tag/webservice/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/website/index.html
+++ b/tag/website/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/websocket/index.html
+++ b/tag/websocket/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/weekly-news/index.html
+++ b/tag/weekly-news/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/weekly_news/index.html
+++ b/tag/weekly_news/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/whitebalance/index.html
+++ b/tag/whitebalance/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/whitepaper/index.html
+++ b/tag/whitepaper/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/wiki/index.html
+++ b/tag/wiki/index.html
@@ -23,15 +23,10 @@
 I like to give a very subjective overview about the current state, so the rumors have something to eat ;-)" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/windows/index.html
+++ b/tag/windows/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/wine/index.html
+++ b/tag/wine/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/winehq/index.html
+++ b/tag/winehq/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/workshop/index.html
+++ b/tag/workshop/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/workstation-7-1-3/index.html
+++ b/tag/workstation-7-1-3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/writing/index.html
+++ b/tag/writing/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/wsl/index.html
+++ b/tag/wsl/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/wxruby/index.html
+++ b/tag/wxruby/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/x-org/index.html
+++ b/tag/x-org/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/x64/index.html
+++ b/tag/x64/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/x86/index.html
+++ b/tag/x86/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/x86_64/index.html
+++ b/tag/x86_64/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/xfce/index.html
+++ b/tag/xfce/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/xml/index.html
+++ b/tag/xml/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/xorg-2/index.html
+++ b/tag/xorg-2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/xorg-2/page/2/index.html
+++ b/tag/xorg-2/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/xorg-2/page/3/index.html
+++ b/tag/xorg-2/page/3/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/xorg-2/page/4/index.html
+++ b/tag/xorg-2/page/4/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/xpath/index.html
+++ b/tag/xpath/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/xslt/index.html
+++ b/tag/xslt/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/y2base/index.html
+++ b/tag/y2base/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/yast-development/index.html
+++ b/tag/yast-development/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/yast/index.html
+++ b/tag/yast/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/yast/page/2/index.html
+++ b/tag/yast/page/2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/yast2/index.html
+++ b/tag/yast2/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ycp/index.html
+++ b/tag/ycp/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/ydialogspy/index.html
+++ b/tag/ydialogspy/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/yumi/index.html
+++ b/tag/yumi/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/znc/index.html
+++ b/tag/znc/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/zoom/index.html
+++ b/tag/zoom/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/zurich/index.html
+++ b/tag/zurich/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>

--- a/tag/zypper/index.html
+++ b/tag/zypper/index.html
@@ -21,15 +21,10 @@
   <meta property="og:description" content="" />
 
   <!-- include JS from static.opensuse.org -->
-  <script src="//static.opensuse.org/themes/bento/js/jquery.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   <!-- This is for local development:
-  <script src="https://lizards.opensuse.org/wp-content/themes/bento/js/script.js" type="text/javascript" charset="utf-8"></script>
   -->
 
   <!-- translated global navigation -->
-  <script src="//static.opensuse.org/themes/bento/js/l10n/global-navigation-data-en_US.js" type="text/javascript" charset="utf-8"></script>
-  <script src="//static.opensuse.org/themes/bento/js/global-navigation.js" type="text/javascript" charset="utf-8"></script>
 
   <!-- social service scripts -->
   <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>


### PR DESCRIPTION
The jquery version referenced in all the *.html pages is vulnerable to CVE-2012-6708.

While thinking on how to upgrade the really old version to a more current one without breaking too much, I just realized that especially the Lizards pages are not really making use of this. They even make not really use of the other referenced javascript snipplets....

So I decided to remove the following java script references from all *.html files, which were hosted at static.opensuse.org (or locally) at some point in time - but some are even already removed:

- jquery.js
- script.js
- global-navigation-data-en_US.js
- global-navigation.js

Note: I kept the references to the external java script files:
- platform.twitter.com/widgets.js
- apis.google.com/js/plusone.js

which IMHO could also be removed without a problem (allowing to get rid of external tracking). But this might be worth to get tracked in another PR (maybe together with the inline Javascript?).

The main point here is to get rid of the vulnerable jquery.js ....



